### PR TITLE
chore: PR 종료 시 Cloudflare Preview Worker 자동 삭제 파이프라인 추가

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,42 @@
+name: Cleanup Preview Cloudflare Worker
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10.26.2
+      
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.12.0'
+          cache: 'pnpm'
+      
+      - name: Delete Preview Worker
+        run: |
+          pnpm wrangler delete --name unibusk-preview-${{ github.event.pull_request.number }} --force
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## 🗑️ Preview Worker Deleted
+              
+              Worker \`unibusk-preview-${prNumber}\` has been removed from Cloudflare.
+              `
+            });


### PR DESCRIPTION
## 관련 이슈
Closes #5

## 변경사항

PR이 종료될 때 생성된 Preview Worker를 자동으로 삭제하는 GitHub Actions 파이프라인을 추가했습니다.

신규 파일:
- .github/workflows/cleanup-preview.yml

워크플로우 기능:
- PR close 이벤트 감지
- wrangler delete 명령으로 Preview Worker 자동 삭제
- GitHub Script로 PR 댓글에 삭제 완료 알림 작성

## 리뷰 포인트

- PR close 이벤트에서 워크플로우가 정상 트리거되는지 확인
- Cloudflare API 권한 설정이 올바르게 구성되었는지 검증
- Preview Worker 삭제가 정상 완료되는지 확인
- PR 댓글이 정상 작성되는지 검증

## 추가 정보
워크플로우는 PR 번호 기반으로 해당 Preview Worker를 식별하여 삭제합니다. 향후 여러 Preview 환경이 증가해도 개별 관리가 가능한 구조로 설계되었습니다.

#6, #8, #10 PR 분리 이유: PR #6에서 Preview Worker 삭제 파이프라인을 한 번에 구현할 수 있는 규모였으나, PR을 closed 해야만 워크플로우가 트리거되므로 검증 및 문제 해결을 위해 PR #8(wrangler actions 전환), PR #10(pnpm 환경 설정)으로 분리하여 점진적으로 개선했습니다.
