### PR TITLE
chore: Preview Worker 삭제 워크플로우에 pnpm 환경 설정 추가

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -14,6 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10.26.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.12.0'
+          cache: 'pnpm'
+
       - name: Delete Preview Worker
         id: delete
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## 관련 이슈
Closes #9

## 변경사항

Preview Worker 삭제 워크플로우에서 pnpm을 사용하기 위한 환경 설정을 추가했습니다.

주요 변경:
- cleanup-preview.yml에 pnpm/action-setup@v3 추가 (pnpm 10.26.2)
- actions/setup-node@v4 추가 (Node 24.12.0, pnpm 캐싱)

cloudflare/wrangler-action@v3이 pnpm을 사용하므로, 워크플로우 실행 전에 사전 설치가 필요합니다.

## 리뷰 포인트

- PR close 이벤트에서 pnpm 설치가 정상 진행되는지 확인
- 의존성 캐싱이 정상 작동하는지 검증
- wrangler-action이 pnpm 환경에서 정상 실행되는지 확인

## 추가 정보

로컬 mise.toml과 동일한 버전(pnpm 10.26.2, Node 24.12.0)으로 설정하여 로컬-CI 환경 일관성을 유지합니다.

#6, #8, #10 PR 분리 이유: PR #6에서 Preview Worker 삭제 파이프라인을 한 번에 구현할 수 있는 규모였으나, PR을 closed 해야만 워크플로우가 트리거되므로 검증 및 문제 해결을 위해 PR #8(wrangler actions 전환), PR #10(pnpm 환경 설정)으로 분리하여 점진적으로 개선했습니다.
