### PR TITLE
chore: Preview Worker 삭제 워크플로우에 수동 실행 기능 추가 및 npm 전환

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -3,6 +3,12 @@ name: Cleanup Preview Worker
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to clean up'
+        required: true
+        type: number
 
 permissions:
   contents: read
@@ -13,30 +19,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set PR Number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          fi
       
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 10.26.2
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24.12.0'
-          cache: 'pnpm'
-
       - name: Delete Preview Worker
         id: delete
-        uses: cloudflare/wrangler-action@v3
         continue-on-error: true
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: delete --name unibusk-preview-${{ github.event.pull_request.number }}
+        run: npx wrangler@latest delete --name unibusk-preview-${{ steps.pr.outputs.number }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       
       - name: Comment on PR
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = context.payload.pull_request.number;
+            const prNumber = ${{ steps.pr.outputs.number }};
             const success = '${{ steps.delete.outcome }}' === 'success';
             const emoji = success ? '✅' : '⚠️';
             const message = success 


### PR DESCRIPTION
## 관련 이슈
Closes #17

## 변경사항

Preview Worker 삭제 워크플로우에 수동 실행 기능을 추가하고 pnpm 설치 단계를 제거했습니다.

주요 변경:
- cleanup-preview.yml에 workflow_dispatch 이벤트 추가
- 수동 실행 시 PR 번호를 입력 파라미터로 받음
- 자동/수동 이벤트 구분하여 PR 댓글 작성 여부 결정
- wrangler CLI 직접 사용으로 pnpm 설치 단계 제거
- pnpm/action-setup@v3, actions/setup-node@v4 제거

트리거 조건:
- 자동: PR close 이벤트
- 수동: GitHub Actions UI에서 "Run workflow" 클릭 (PR 번호 입력)

## 리뷰 포인트

- GitHub Actions UI에서 수동 실행 옵션이 정상 표시되는지 확인
- 수동 실행 시 워크플로우가 정상 동작하는지 검증
- Preview Worker가 정상 삭제되는지 확인
- 자동 이벤트와 수동 이벤트에서 동작이 다른지 검증

## 추가 정보

pnpm 10.22.0부터 도입된 trust policy 기능으로 인해 provenance가 없는 패키지 설치가 차단되는 문제가 해결되었습니다. wrangler CLI는 Node.js에 기본 포함되어 있으므로 추가 설치가 불필요합니다.