### PR TITLE
chore: shadcn/ui components.json을 프로젝트 폴더 구조에 맞게 수정

### DIFF
--- a/components.json
+++ b/components.json
@@ -5,18 +5,18 @@
   "tsx": true,
   "tailwind": {
     "config": "",
-    "css": "app/globals.css",
+    "css": "src/styles/globals.css",
     "baseColor": "neutral",
     "cssVariables": true,
     "prefix": ""
   },
   "iconLibrary": "lucide",
   "aliases": {
-    "components": "@/src/shared/ui",
-    "utils": "@/src/shared/lib/utils",
-    "ui": "@/src/shared/ui",
-    "lib": "@/src/shared/lib",
-    "hooks": "@/src/shared/hooks"
+    "components": "@/components/common",
+    "utils": "@/utils",
+    "ui": "@/components/common",
+    "lib": "@/utils/lib",
+    "hooks": "@/hooks"
   },
   "registries": {}
 }


### PR DESCRIPTION
## 관련 이슈
Closes #21

## 변경사항

shadcn/ui 설정 파일(components.json)을 확정된 프로젝트 폴더 구조에 맞게 업데이트했습니다.

변경 내용:
- tailwind.css 경로: app/globals.css → src/styles/globals.css
- components alias: @/src/shared/ui → @/components/common
- utils alias: @/src/shared/lib/utils → @/utils
- hooks alias: @/src/shared/hooks → @/hooks

tsconfig.json의 paths 설정과 일치하여 shadcn/ui 컴포넌트 설치 시 올바른 경로에 생성됩니다.

## 리뷰 포인트

- components.json의 aliases가 tsconfig.json paths와 일치하는지 확인
- 새로운 shadcn/ui 컴포넌트 설치 테스트 (올바른 경로 생성 확인)
- 기존 설치된 컴포넌트들의 import 경로가 유효한지 검증