### PR TITLE
chore: zustand 라이브러리 설치

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-dom": "19.0.3",
     "react-hook-form": "^7.70.0",
     "tailwind-merge": "^3.4.0",
-    "zod": "^4.3.4"
+    "zod": "^4.3.4",
+    "zustand": "^5.0.10"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^6.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       zod:
         specifier: ^4.3.4
         version: 4.3.4
+      zustand:
+        specifier: ^5.0.10
+        version: 5.0.10(@types/react@19.2.7)(react@19.0.3)(use-sync-external-store@1.6.0(react@19.0.3))
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^6.7.3
@@ -6401,6 +6404,24 @@ packages:
 
   zod@4.3.4:
     resolution: {integrity: sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A==}
+
+  zustand@5.0.10:
+    resolution: {integrity: sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -13914,5 +13935,11 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.4: {}
+
+  zustand@5.0.10(@types/react@19.2.7)(react@19.0.3)(use-sync-external-store@1.6.0(react@19.0.3)):
+    optionalDependencies:
+      '@types/react': 19.2.7
+      react: 19.0.3
+      use-sync-external-store: 1.6.0(react@19.0.3)
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## 관련 이슈
Closes #22

## 변경사항

클라이언트 전역 상태 관리를 위해 zustand v5.0.10을 설치했습니다.

설치 내용:
- zustand@5.0.10 추가
- React 19.0.3과 호환

## 리뷰 포인트

- package.json 의존성이 올바르게 추가되었는지 확인
- pnpm-lock.yaml이 최신 상태로 동기화되었는지 검증