### PR TITLE
fix: 스토리북 Vitest 테스트에서 env 파일 로드 추가

### DIFF
--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -1,6 +1,19 @@
+import path from 'node:path';
 import * as a11yAddonAnnotations from '@storybook/addon-a11y/preview';
 import { setProjectAnnotations } from '@storybook/nextjs-vite';
 import * as projectAnnotations from './preview';
+
+function loadEnvFile(relativePath: string) {
+  try {
+    process.loadEnvFile(path.resolve(process.cwd(), relativePath));
+  }
+  catch {
+    // 파일이 없으면 pass
+  }
+}
+
+loadEnvFile('.env.local');
+loadEnvFile('.env');
 
 // This is an important step to apply the right configuration when testing your stories.
 // More info at: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations


### PR DESCRIPTION
## 관련 이슈

<!-- 이슈 번호를 입력하세요. -->

Closes #32 

# 변경사항

- Storybook Vitest 테스트 실행 시 `.env.local`과 `.env`를 명시적으로 로드하도록 설정 추가
- env 파일이 없는 환경에서도 테스트가 불필요하게 실패하지 않도록 `try/catch`로 예외 처리
- `pnpm test-storybook`(pre-push 단계)에서 환경변수 미주입으로 `undefined`가 발생하던 케이스 방지
- 프로젝트의 Node 버전이 `mise`로 최신 버전으로 고정되어 있어, 외부 의존성(`dotenv`) 없이 Node 내장 API인 `process.loadEnvFile()`을 사용
    - process.loadEnvFile() 방식은 node.20 ver 이상 지원

## 리뷰 포인트

- `.storybook/vitest.setup.ts`에서 env 로드 순서가 적절한지 확인 부탁드립니다.  
  - 현재: `.env.local` → `.env` (필요 시 우선순위 정책 조정 가능)
- `try/catch`로 파일 부재를 무시하는 방식입니다. 다른 방식의 형태를 알고 계시다면 코멘트 남겨주세요.

## 추가 정보

### 테스트 방법
- `pnpm test-storybook` 실행 후 정상 종료 및 테스트 통과 확인
- `git push` 시 husky `pre-push` 단계에서 `pnpm test-storybook`가 실패하지 않는지 확인

### 참고
- 테스트 통과 사진
<img width="1855" height="986" alt="해결" src="https://github.com/user-attachments/assets/18f05b43-1358-4195-b888-794e2c4432cf" />

