### PR TITLE
fix: CI 빌드에 카카오맵 환경변수 주입

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
           API_URL: ${{ secrets.API_URL }}
           NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
           NEXT_PUBLIC_API_MOCKING: 'enabled'
+          NEXT_PUBLIC_KAKAO_MAP_APP_KEY: ${{ secrets.NEXT_PUBLIC_KAKAO_MAP_APP_KEY }}
         run: pnpm exec opennextjs-cloudflare build
       
       # Cloudflare 배포


### PR DESCRIPTION
## 관련 이슈

<!-- 이슈 번호를 입력하세요. -->

Closes #58 

## 변경사항

<!-- 주요 변경사항을 작성하세요. -->
### 원인
- 배포 환경에서 Kakao SDK 스크립트가 DOM에 생성되지 않아 지도가 렌더링되지 않는 이슈가 있었고,
  빌드 타임에 `NEXT_PUBLIC_*` 환경변수가 주입되지 않아 발생한 문제로 판단했습니다.

### 해결
- GitHub Actions 빌드 단계에 `NEXT_PUBLIC_KAKAO_MAP_APP_KEY` 환경변수를 주입하도록 `deploy.yml` 수정
- 배포 번들에 카카오 JS 키가 포함되어, 프로덕션 환경에서 Kakao SDK 스크립트가 정상 로드되도록 보장

## 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->
- `deploy.yml`의 `NEXT_PUBLIC_KAKAO_MAP_APP_KEY` env 주입이 올바르게 적용되었는지 확인 부탁드립니다.
  
## 추가 정보

<!-- 스크린샷, 테스트 방법 등 추가 정보가 있다면 작성하세요 -->

