### PR TITLE
feat: 공연 둘러보기 페이지에 Header 공통 컴포넌트 적용

### DIFF
--- a/src/app/performance-list/page.tsx
+++ b/src/app/performance-list/page.tsx
@@ -1,6 +1,7 @@
 import type { PerformanceFilterTab } from '@/types/performance';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import { Suspense } from 'react';
+import { Header } from '@/components/common/header';
 import { getQueryClient } from '@/queries';
 import { performanceListInfiniteQueryOptions } from '@/queries/performance';
 import { isValidPerformanceTab } from '@/types/performance';
@@ -26,15 +27,19 @@ export default async function PerformanceListPage({ searchParams }: PageProps) {
   await queryClient.prefetchInfiniteQuery(performanceListInfiniteQueryOptions(tab));
 
   return (
-    <main className="container-1920 min-h-screen bg-white pt-55">
-      <Hero />
-      <HydrationBoundary state={dehydrate(queryClient)}>
-        <Suspense fallback={<div>로딩 중...</div>}>
-          <PerformanceTabs
-            defaultTab={tab}
-          />
-        </Suspense>
-      </HydrationBoundary>
-    </main>
+    <div className="relative mt-5 container-1920 flex min-h-screen flex-col">
+      <Header />
+      <main className="container-1920 min-h-screen bg-white pt-[57px]">
+
+        <Hero />
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          <Suspense fallback={<div>로딩 중...</div>}>
+            <PerformanceTabs
+              defaultTab={tab}
+            />
+          </Suspense>
+        </HydrationBoundary>
+      </main>
+    </div>
   );
 }

--- a/src/app/performance-list/page.tsx
+++ b/src/app/performance-list/page.tsx
@@ -29,7 +29,7 @@ export default async function PerformanceListPage({ searchParams }: PageProps) {
   return (
     <div className="relative mt-5 container-1920 flex min-h-screen flex-col">
       <Header />
-      <main className="container-1920 min-h-screen bg-white pt-[57px]">
+      <main className="min-h-screen bg-white pt-[57px]">
 
         <Hero />
         <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/components/common/dialog/dialog.tsx
+++ b/src/components/common/dialog/dialog.tsx
@@ -38,7 +38,7 @@ function DialogOverlay({
       data-slot="dialog-overlay"
       className={cn(
         `
-          fixed inset-0 z-50 bg-black/50
+          fixed inset-0 z-modal bg-black/50
           data-[state=closed]:animate-out data-[state=closed]:fade-out-0
           data-[state=open]:animate-in data-[state=open]:fade-in-0
         `,

--- a/src/components/performance/register-modal.tsx
+++ b/src/components/performance/register-modal.tsx
@@ -96,9 +96,10 @@ export function RegisterModal({ isOpen, onClose }: RegistrationModalProps) {
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent
-        className={`
-          h-175 w-300 max-w-none rounded-lg border-none p-[80px_122px] shadow-xl
-        `}
+        className={cn(`
+          z-modal h-175 w-300 max-w-none rounded-lg border-none p-[80px_122px]
+          shadow-xl
+        `)}
         showCloseButton={false}
       >
         <button

--- a/src/components/performance/search-modal.tsx
+++ b/src/components/performance/search-modal.tsx
@@ -84,7 +84,8 @@ export function SearchModal({ onSelect, trigger }: LocationSearchModalProps) {
       </DialogTrigger>
       <DialogContent
         className={`
-          flex h-170 w-125 flex-col gap-0 rounded-lg border-none px-10 pt-12
+          z-popup flex h-170 w-125 flex-col gap-0 rounded-lg border-none px-10
+          pt-12
         `}
         showCloseButton={false}
       >


### PR DESCRIPTION
## 관련 이슈
Closes #140

## 변경사항

공연 목록 페이지에 Header를 추가하여 전체 페이지 레이아웃을 통일했습니다.

### 주요 작업
- Header 컴포넌트 추가
- 페이지 구조: main → div + Header + main으로 변경
- 상단 패딩 조정: pt-55 → pt-[57px] (Header 높이 맞춤)
- z-index 토큰화: z-50 → z-modal, z-popup 추가

## 리뷰 포인트

- Header가 페이지 최상단에 정상 표시되는지 확인
- Header 높이만큼 콘텐츠 영역이 패딩되는지 검증
- z-index 토큰이 모달들에 정상 적용되는지 확인