### PR TITLE
hotfix: 상세 패널 스크롤 이슈 수정

### DIFF
--- a/src/app/busking-map/_components/detail-panel.tsx
+++ b/src/app/busking-map/_components/detail-panel.tsx
@@ -187,7 +187,8 @@ function EmptyPerformances({ tab }: { tab: PerformanceTab }) {
   return (
     <div
       className={`
-        flex w-full items-center justify-center px-6 py-7.75 pb-34 text-center
+        flex min-h-40 w-full items-center justify-center px-6 pt-7.75 pb-50
+        text-center
       `}
     >
       <p className="typo-caption-r-1 whitespace-pre-line text-gray-500">{message}</p>
@@ -283,7 +284,7 @@ function LocationPerformancesSection({ performanceLocationId }: { performanceLoc
                   <EmptyPerformances tab={activeTab} />
                 )
               : (
-                  <div className="mt-5.5 grid grid-cols-2 gap-4">
+                  <div className="mt-5.5 grid grid-cols-2 gap-4 pb-13">
                     {performances.map(performance => (
                       <PerformanceCard
                         key={performance.id}


### PR DESCRIPTION
## 관련 이슈

<!-- 이슈 번호를 입력하세요. -->

Closes #145 

## 변경사항

<!-- 주요 변경사항을 작성하세요. -->
※ 문제상황
- 상세 패널에서 스크롤시 header 크기 이하로 스크롤 될 시, 헤더가 fixed로 변하다 다시 강제로 원상복귀되어 어색한 ui 현상 발생

※ 해결
- header 크기 이상의 하단 여백을 마련하여 정상적으로 스크롤 될 수 있도록 수정
- 와이어프레임 상으로도 수정사항 반영한 사항이 더 자연스러움


## 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->
- 상세 패널이 스크롤 모션이 정상 작동하는지

## 추가 정보

<!-- 스크린샷, 테스트 방법 등 추가 정보가 있다면 작성하세요 -->
![스크롤 이슈](https://github.com/user-attachments/assets/8026b48b-06f1-443e-a679-b3d13af11419)
