### PR TITLE
perf: 버스킹맵 default level 및 클러스터 level 변경

### DIFF
--- a/src/constants/kakao-map/kakao-map.ts
+++ b/src/constants/kakao-map/kakao-map.ts
@@ -4,8 +4,8 @@ export const KAKAO_MAP_LIBRARIES = ['services', 'clusterer'] as const; // 추가
 
 export const CLUSTER_CLICK_GUARD_MS = 150;
 
-export const DEFAULT_LEVEL = 5;
-export const DEFAULT_CLUSTER_MIN_LEVEL = 6;
+export const DEFAULT_LEVEL = 6;
+export const DEFAULT_CLUSTER_MIN_LEVEL = 5;
 export const DEFAULT_CENTER = { lat: 37.55515, lng: 126.9369 };
 
 /**


### PR DESCRIPTION
## 관련 이슈

<!-- 이슈 번호를 입력하세요. -->

Closes #147

## 변경사항

<!-- 주요 변경사항을 작성하세요. -->
※ 기존 클러스터 그룹핑 조건이 널널해 마커가 붙어있는 듯한 느낌임에도 클러스터링 되지 않는 문제가 발생
 - deafult level 변경: 5 -> 6
 - cluster level 변경: 6 -> 5

## 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->
- 초기 화면에 버스킹 장소가 눈에 잘 들어오는지 확인
- 마커 ↔ 클러스터 마커 전환 level이 적합한지 확인
