### PR TITLE
fix: 공연 등록 페이지 장소 검색 예시 및 placeholder 개선

### DIFF
--- a/src/components/performance/search-modal.tsx
+++ b/src/components/performance/search-modal.tsx
@@ -109,7 +109,7 @@ export function SearchModal({ onSelect, trigger }: LocationSearchModalProps) {
         <SearchInput
           value={keyword}
           onChange={handleKeywordChange}
-          placeholder="예) 신촌 스타광장"
+          placeholder="예) 걷고싶은거리 버스킹존"
           onKeyDown={e => e.key === 'Enter' && handleSearch()}
           className={cn(`pb-2.5`)}
         />
@@ -127,7 +127,7 @@ export function SearchModal({ onSelect, trigger }: LocationSearchModalProps) {
                         className="typo-caption-m-1 text-black"
                       >
                         <span className="block">
-                          {`·${item.title}`}
+                          {`${item.title}`}
                         </span>
                         <span className="block pl-1 text-gray-550">{item.example}</span>
                       </li>

--- a/src/constants/performance/register.ts
+++ b/src/constants/performance/register.ts
@@ -30,15 +30,15 @@ export const STEP_FIELDS: Record<1 | 2 | 3 | 4, (keyof PerformanceRegisterForm)[
 export const SEARCH_EXAMPLES = [
   {
     title: '장소명',
-    example: '예) 신촌 스타광장',
+    example: '예) 걷고싶은거리 버스킹존',
+  },
+  {
+    title: '지역명(서울 구 단위)',
+    example: '예) 마포구',
   },
   {
     title: '도로명 + 건물번호',
-    example: '예) 연세로 19',
-  },
-  {
-    title: '지역명(동/리) + 지번',
-    example: '예) 창천동 18-53',
+    example: '예) 어울마당로 107',
   },
 ] as const;
 


### PR DESCRIPTION
## 관련 이슈
Closes #154

## 변경사항

검색 예시를 실제 버스킹 장소 기반으로 개선했습니다.

### 수정 사항
- Placeholder: "신촌 스타광장" → "걷고싶은거리 버스킹존"
- SEARCH_EXAMPLES 업데이트
  → 장소명: "신촌 스타광장" → "걷고싶은거리 버스킹존"
  → 지역명 추가 (마포구)
  → 도로명: "연세로 19" → "어울마당로 107"
- 불릿 포인트(·) 제거

## 리뷰 포인트

- 변경된 검색 예시가 실제로 데이터베이스에 존재하는지 확인
- Placeholder와 예시가 일관성 있게 적용되었는지 검토