### PR TITLE
fix: 버스킹맵 마커 깜빡힘 현상 제거

### DIFF
--- a/src/hooks/performance-locations/use-performance-locations-map.ts
+++ b/src/hooks/performance-locations/use-performance-locations-map.ts
@@ -1,6 +1,5 @@
 import type { Bounds } from '@/types/busking-map/busking-place';
-import { useQuery } from '@tanstack/react-query';
-
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { getPerformanceLocations } from '@/apis/performance-locations';
 import { performanceLocationKeys } from '@/queries/performance-locations';
 
@@ -10,6 +9,7 @@ export function usePerformanceLocationsMap(bounds: Bounds | null) {
   return useQuery({
     queryKey: performanceLocationKeys.map(bounds),
     enabled: isEnabled,
+    placeholderData: keepPreviousData,
     queryFn: () => {
       if (!bounds) {
         throw new TypeError('bounds 값이 필요합니다.');


### PR DESCRIPTION

## 관련 이슈

<!-- 이슈 번호를 입력하세요. -->

Closes #164 

## 변경사항
- tanstack query의 placeholderData: keepPreviousData를 적용해 bounds 변경 refetch 중 데이터 공백을 제거
- places가 순간적으로 []이 되며 마커가 전체 리셋되던 깜빡임을 완화

<!-- 주요 변경사항을 작성하세요. -->

## 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->
- 마커 깜빡임 제거


## 추가 정보
- 클러스터 마커는 추후 깜빡임 제거
<!-- 스크린샷, 테스트 방법 등 추가 정보가 있다면 작성하세요 -->