### PR TITLE
fix: 클러스터 배지 깜빡임 현상 제거

### DIFF
--- a/src/components/kakao-map/kakao-map-view.tsx
+++ b/src/components/kakao-map/kakao-map-view.tsx
@@ -11,6 +11,7 @@ import { useKakaoMap } from '@/hooks/kakao-map/use-kakao-map';
 import { useKakaoMarkers } from '@/hooks/kakao-map/use-kakao-markers';
 import { useBuskingMapUiStore } from '@/stores/busking-map';
 import { cn } from '@/utils';
+import { buildClusterKeyFromCenter } from '@/utils/kakao-map';
 import { ClusterBadge } from './cluster-badge';
 
 interface KakaoMapViewProps {
@@ -20,10 +21,6 @@ interface KakaoMapViewProps {
   className?: string;
   enableClusterer?: boolean;
   clusterMinLevel?: number;
-}
-
-function buildClusterKeyFromCenter(center: kakao.maps.LatLng) {
-  return `${center.getLat().toFixed(5)},${center.getLng().toFixed(5)}`;
 }
 
 export function KakaoMapView({

--- a/src/hooks/kakao-map/use-kakao-clusterer.ts
+++ b/src/hooks/kakao-map/use-kakao-clusterer.ts
@@ -6,6 +6,7 @@ import type { KakaoMarkerInputs } from '@/types/kakao/kakao-map';
 import { useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { CLUSTER_BADGE_SIZE_PX } from '@/constants/busking-map';
+import { buildClusterKeyFromCenter } from '@/utils/kakao-map/build-cluster-key-from-center';
 
 interface UseKakaoClustererOptions {
   enabled: boolean;
@@ -18,7 +19,12 @@ interface UseKakaoClustererOptions {
 interface OverlayEntry {
   badgeReactRoot: Root;
   badgeLayerEl: HTMLDivElement;
+  containerEl: HTMLDivElement;
   count: number;
+
+  // clusterclick이 content 교체로 끊기는 케이스가 있어, DOM click 브릿지를 위해 보관
+  cluster: kakao.maps.Cluster | null;
+  markerIds: string[];
 }
 
 interface RenderClusterBadge {
@@ -44,11 +50,11 @@ export function useKakaoClusterer(
   // 마커 인스턴스 → id 역매핑(WeakMap: 마커 GC 시 매핑도 함께 정리)
   const markerIdByInstanceRef = useRef<WeakMap<kakao.maps.Marker, string>>(new WeakMap());
 
-  // CustomOverlay별 React root/container를 추적해 배지를 갱신하고 누수 없이 정리
-  const overlayRootMapRef = useRef<Map<kakao.maps.CustomOverlay, OverlayEntry>>(new Map());
+  // clusterKey별 React root/container를 추적해 배지를 갱신하고 누수 없이 정리
+  const overlayEntryByClusterKeyRef = useRef<Map<string, OverlayEntry>>(new Map());
 
-  // 마지막으로 클릭된 클러스터 overlay(배지 active 스타일용)
-  const activeOverlayRef = useRef<kakao.maps.CustomOverlay | null>(null);
+  // 마지막으로 클릭된 클러스터 key(배지 active 스타일용)
+  const activeClusterKeyRef = useRef<string | null>(null);
 
   // 최신 동작 보장
   const renderRef = useRef(renderClusterBadge);
@@ -76,14 +82,14 @@ export function useKakaoClusterer(
       return;
     }
 
-    const prevActiveOverlay = activeOverlayRef.current;
-    if (!prevActiveOverlay) {
+    const prevActiveClusterKey = activeClusterKeyRef.current;
+    if (!prevActiveClusterKey) {
       return;
     }
 
-    activeOverlayRef.current = null;
+    activeClusterKeyRef.current = null;
 
-    const overlayEntry = overlayRootMapRef.current.get(prevActiveOverlay);
+    const overlayEntry = overlayEntryByClusterKeyRef.current.get(prevActiveClusterKey);
     if (!overlayEntry) {
       return;
     }
@@ -119,7 +125,7 @@ export function useKakaoClusterer(
     };
   }, []);
 
-  // clusterer 생성 + clustered/clusterclick 이벤트 연결 + overlay 배지 렌더링
+  // clusterer 생성 + clustered 이벤트 연결 + overlay 배지 렌더링
   useEffect(() => {
     if (!isClustererEnabled || !map || !window.kakao?.maps) {
       return;
@@ -133,25 +139,46 @@ export function useKakaoClusterer(
     const kakaoMaps = window.kakao.maps;
 
     // 로컬 변수 캡처로 cleanup에서 동일 참조를 사용(Ref 변경 경고 방지)
-    const overlayRootMap = overlayRootMapRef.current;
+    const overlayEntryByClusterKey = overlayEntryByClusterKeyRef.current;
 
-    const pendingDisposeMap = new Map<kakao.maps.CustomOverlay, OverlayEntry>();
+    const pendingDisposeMap = new Map<string, OverlayEntry>();
     let disposeTimer: number | null = null;
 
+    const ensureOverlayContent = (overlay: kakao.maps.CustomOverlay, containerEl: HTMLDivElement) => {
+      const content = overlay.getContent();
+      if (typeof content === 'string' || content !== containerEl) {
+        overlay.setContent(containerEl);
+      }
+    };
+
+    const renderEntry = (clusterKey: string) => {
+      const overlayEntry = overlayEntryByClusterKey.get(clusterKey);
+      if (!overlayEntry) {
+        return;
+      }
+
+      const isActive = activeClusterKeyRef.current === clusterKey;
+      overlayEntry.badgeReactRoot.render(renderRef.current({ count: overlayEntry.count, isActive }));
+    };
+
     const flushOverlayDisposals = () => {
-      pendingDisposeMap.forEach((overlayEntry, overlay) => {
-        const current = overlayRootMap.get(overlay);
+      pendingDisposeMap.forEach((overlayEntry, clusterKey) => {
+        const current = overlayEntryByClusterKey.get(clusterKey);
         if (!current || current !== overlayEntry) {
           return;
         }
 
-        if (activeOverlayRef.current === overlay) {
-          activeOverlayRef.current = null;
+        if (activeClusterKeyRef.current === clusterKey) {
+          activeClusterKeyRef.current = null;
         }
+
+        overlayEntry.containerEl.onclick = null;
 
         overlayEntry.badgeReactRoot.unmount();
         overlayEntry.badgeLayerEl.remove();
-        overlayRootMap.delete(overlay);
+        overlayEntry.containerEl.remove();
+
+        overlayEntryByClusterKey.delete(clusterKey);
       });
 
       pendingDisposeMap.clear();
@@ -168,13 +195,12 @@ export function useKakaoClusterer(
       }, 0);
     };
 
-    const queueOverlayDisposal = (overlay: kakao.maps.CustomOverlay, overlayEntry: OverlayEntry) => {
-      if (pendingDisposeMap.has(overlay)) {
+    const queueOverlayDisposal = (clusterKey: string, overlayEntry: OverlayEntry) => {
+      if (pendingDisposeMap.has(clusterKey)) {
         return;
       }
 
-      pendingDisposeMap.set(overlay, overlayEntry);
-      overlayEntry.badgeReactRoot.render(null);
+      pendingDisposeMap.set(clusterKey, overlayEntry);
       scheduleFlushOverlayDisposals();
     };
 
@@ -199,39 +225,30 @@ export function useKakaoClusterer(
       clusterer.redraw();
     }
 
-    const renderOverlay = (overlay: kakao.maps.CustomOverlay) => {
-      const overlayEntry = overlayRootMap.get(overlay);
-      if (!overlayEntry) {
-        return;
-      }
-
-      const isActive = activeOverlayRef.current === overlay;
-      overlayEntry.badgeReactRoot.render(renderRef.current({ count: overlayEntry.count, isActive }));
-    };
-
-    // overlay가 있으면 갱신, 없으면 생성해서 연결
-    const upsertOverlay = (overlay: kakao.maps.CustomOverlay, count: number) => {
-      const overlayEntry = overlayRootMap.get(overlay);
-      const isActive = activeOverlayRef.current === overlay;
+    // clusterKey가 있으면 갱신, 없으면 생성해서 연결
+    // overlay 인스턴스가 교체되어도 같은 clusterKey면 동일 DOM/ReactRoot를 setContent로 재부착
+    const upsertOverlay = (
+      clusterKey: string,
+      overlay: kakao.maps.CustomOverlay,
+      cluster: kakao.maps.Cluster,
+      markerIds: string[],
+      count: number,
+    ) => {
+      const overlayEntry = overlayEntryByClusterKey.get(clusterKey);
+      const isActive = activeClusterKeyRef.current === clusterKey;
 
       if (!overlayEntry) {
-        const content = overlay.getContent();
-        const overlayContentEl = typeof content === 'string' ? document.createElement('div') : content;
-
-        if (typeof content === 'string') {
-          overlay.setContent(overlayContentEl);
-        }
-
-        overlayContentEl.style.width = `${CLUSTER_BADGE_SIZE_PX}px`;
-        overlayContentEl.style.height = `${CLUSTER_BADGE_SIZE_PX}px`;
-        overlayContentEl.style.cursor = 'pointer';
-        overlayContentEl.style.position = 'relative';
+        const containerEl = document.createElement('div');
+        containerEl.style.width = `${CLUSTER_BADGE_SIZE_PX}px`;
+        containerEl.style.height = `${CLUSTER_BADGE_SIZE_PX}px`;
+        containerEl.style.cursor = 'pointer';
+        containerEl.style.position = 'relative';
         // 브라우저 기본 focus outline 삭제
-        overlayContentEl.style.outline = 'none';
-        overlayContentEl.style.border = '0';
-        overlayContentEl.style.boxShadow = 'none';
-        overlayContentEl.style.background = 'transparent';
-        overlayContentEl.tabIndex = -1;
+        containerEl.style.outline = 'none';
+        containerEl.style.border = '0';
+        containerEl.style.boxShadow = 'none';
+        containerEl.style.background = 'transparent';
+        containerEl.tabIndex = -1;
 
         const badgeMountEl = document.createElement('div');
         badgeMountEl.style.position = 'absolute';
@@ -240,86 +257,95 @@ export function useKakaoClusterer(
         badgeMountEl.style.height = '100%';
         badgeMountEl.style.pointerEvents = 'none';
 
-        overlayContentEl.appendChild(badgeMountEl);
+        containerEl.appendChild(badgeMountEl);
+
+        ensureOverlayContent(overlay, containerEl);
 
         const overlayReactRoot = createRoot(badgeMountEl);
         overlayReactRoot.render(renderRef.current({ count, isActive }));
 
-        overlayRootMap.set(overlay, {
+        overlayEntryByClusterKey.set(clusterKey, {
           badgeReactRoot: overlayReactRoot,
           badgeLayerEl: badgeMountEl,
+          containerEl,
           count,
+          cluster,
+          markerIds,
         });
+
+        // clusterclick이 content 교체로 끊기는 케이스가 있어, DOM click으로 전이를 보장합니다.
+        containerEl.onclick = (event: MouseEvent) => {
+          event.preventDefault();
+          event.stopPropagation();
+
+          const prevActiveClusterKey = activeClusterKeyRef.current;
+          if (prevActiveClusterKey !== clusterKey) {
+            activeClusterKeyRef.current = clusterKey;
+
+            if (prevActiveClusterKey) {
+              renderEntry(prevActiveClusterKey);
+            }
+          }
+
+          renderEntry(clusterKey);
+
+          const entry = overlayEntryByClusterKey.get(clusterKey);
+          if (!entry || !entry.cluster) {
+            return;
+          }
+
+          onClusterClickRef.current?.(entry.cluster, entry.markerIds);
+        };
 
         return;
       }
 
       overlayEntry.count = count;
+      overlayEntry.cluster = cluster;
+      overlayEntry.markerIds = markerIds;
+
+      ensureOverlayContent(overlay, overlayEntry.containerEl);
       overlayEntry.badgeReactRoot.render(renderRef.current({ count, isActive }));
     };
 
-    // prune: 이번 clustered 계산에 포함되지 않은 overlay 정리
-    const removeStaleOverlays = (activeOverlays: Set<kakao.maps.CustomOverlay>) => {
-      overlayRootMap.forEach((overlayEntry, overlay) => {
-        if (activeOverlays.has(overlay)) {
+    // prune: 이번 clustered 계산에 포함되지 않은 clusterKey 정리
+    const removeStaleEntries = (activeClusterKeys: Set<string>) => {
+      overlayEntryByClusterKey.forEach((overlayEntry, clusterKey) => {
+        if (activeClusterKeys.has(clusterKey)) {
           return;
         }
 
-        queueOverlayDisposal(overlay, overlayEntry);
+        queueOverlayDisposal(clusterKey, overlayEntry);
       });
     };
 
     const handleClustered = (clusters: kakao.maps.Cluster[]) => {
-      const activeOverlays = new Set<kakao.maps.CustomOverlay>();
+      const activeClusterKeys = new Set<string>();
+      const markerIdByInstance = markerIdByInstanceRef.current;
 
       clusters.forEach((cluster) => {
-        const overlay = cluster.getClusterMarker();
-        activeOverlays.add(overlay);
+        const clusterKey = buildClusterKeyFromCenter(cluster.getCenter());
+        activeClusterKeys.add(clusterKey);
 
-        if (pendingDisposeMap.has(overlay)) {
-          pendingDisposeMap.delete(overlay);
+        if (pendingDisposeMap.has(clusterKey)) {
+          pendingDisposeMap.delete(clusterKey);
         }
 
-        upsertOverlay(overlay, cluster.getSize());
+        const markerIds = cluster.getMarkers()
+          .map(markerInstance => markerIdByInstance.get(markerInstance))
+          .filter((id): id is string => Boolean(id));
+
+        const overlay = cluster.getClusterMarker();
+        upsertOverlay(clusterKey, overlay, cluster, markerIds, cluster.getSize());
       });
 
-      removeStaleOverlays(activeOverlays);
-    };
-
-    // cluster 클릭 시:
-    // 1) 클릭된 overlay를 active로 만들고(이전 active는 해제), 배지 렌더를 갱신
-    // 2) cluster에 포함된 markerIds를 추출해 상위로 전달
-    const handleClusterClick = (cluster: kakao.maps.Cluster) => {
-      const prevActiveOverlay = activeOverlayRef.current;
-      const nextActiveOverlay = cluster.getClusterMarker();
-
-      if (prevActiveOverlay !== nextActiveOverlay) {
-        activeOverlayRef.current = nextActiveOverlay;
-
-        if (prevActiveOverlay) {
-          renderOverlay(prevActiveOverlay);
-        }
-      }
-
-      // 클릭 직후 clustered 렌더가 아직 안 들어왔을 수도 있으니, 우선 upsert로 보장 + active 스타일 반영
-      upsertOverlay(nextActiveOverlay, cluster.getSize());
-
-      const markerIdByInstance = markerIdByInstanceRef.current;
-      const clusterMarkerInstances = cluster.getMarkers();
-
-      const markerIds = clusterMarkerInstances
-        .map(markerInstance => markerIdByInstance.get(markerInstance))
-        .filter((id): id is string => Boolean(id));
-
-      onClusterClickRef.current?.(cluster, markerIds);
+      removeStaleEntries(activeClusterKeys);
     };
 
     kakaoMaps.event.addListener(clusterer, 'clustered', handleClustered);
-    kakaoMaps.event.addListener(clusterer, 'clusterclick', handleClusterClick);
 
     return () => {
       kakaoMaps.event.removeListener(clusterer, 'clustered', handleClustered);
-      kakaoMaps.event.removeListener(clusterer, 'clusterclick', handleClusterClick);
 
       if (disposeTimer !== null) {
         window.clearTimeout(disposeTimer);
@@ -329,21 +355,23 @@ export function useKakaoClusterer(
       // overlay React root 정리(배치 처리)
       const entriesToDispose: OverlayEntry[] = [];
 
-      overlayRootMap.forEach((overlayEntry, overlay) => {
-        pendingDisposeMap.delete(overlay);
+      overlayEntryByClusterKey.forEach((overlayEntry, clusterKey) => {
+        pendingDisposeMap.delete(clusterKey);
+        overlayEntry.containerEl.onclick = null;
         entriesToDispose.push(overlayEntry);
       });
 
-      overlayRootMap.clear();
+      overlayEntryByClusterKey.clear();
       pendingDisposeMap.clear();
 
       cleanupTimerRef.current = window.setTimeout(() => {
         cleanupTimerRef.current = null;
-        activeOverlayRef.current = null;
+        activeClusterKeyRef.current = null;
 
         entriesToDispose.forEach((overlayEntry) => {
           overlayEntry.badgeReactRoot.unmount();
           overlayEntry.badgeLayerEl.remove();
+          overlayEntry.containerEl.remove();
         });
       }, 0);
 

--- a/src/utils/kakao-map/build-cluster-key-from-center.ts
+++ b/src/utils/kakao-map/build-cluster-key-from-center.ts
@@ -1,0 +1,3 @@
+export function buildClusterKeyFromCenter(center: kakao.maps.LatLng) {
+  return `${center.getLat().toFixed(5)},${center.getLng().toFixed(5)}`;
+}

--- a/src/utils/kakao-map/index.ts
+++ b/src/utils/kakao-map/index.ts
@@ -1,2 +1,2 @@
-export { buildClusterKeyFromCenter } from './build-cluster-key-from-center.ts';
+export { buildClusterKeyFromCenter } from './build-cluster-key-from-center';
 export { loadKakaoSdk } from './load-kakao-sdk';

--- a/src/utils/kakao-map/index.ts
+++ b/src/utils/kakao-map/index.ts
@@ -1,1 +1,2 @@
+export { buildClusterKeyFromCenter } from './build-cluster-key-from-center.ts';
 export { loadKakaoSdk } from './load-kakao-sdk';


### PR DESCRIPTION
## 관련 이슈

<!-- 이슈 번호를 입력하세요. -->

Closes #166 

## 변경사항

<!-- 주요 변경사항을 작성하세요. -->

### ※ 원인 분석
- 요약: 기존 클러스터 마커 재계산 과정에서 **동일 클러스터처럼 보이나, 실제로는 새로운 인스턴스를 계속 생성**하고 있던 상황
- 클러스터 마커가 깜박거리는 원인은 Kakao MarkerClusterer는 clustered 재계산 과정에서, 
화면상 동일 클러스터처럼 보이는 상황에서도 CustomOverlay 인스턴스를 교체하는 케이스로 확인됨
    - 기존 구현이 Map<CustomOverlay, OverlayEntry> 형태로 overlay 인스턴스를 식별자로 사용하면서, 인스턴스 교체 시점을 stale로 오판해 기존 배지를 정리(unmount/remove)하고 새로 생성(create/mount)하는 흐름이 반복되어 깜빡임이 발생

### ※ 작업 내용
**1. 클러스터를 식별하는 키(clusterKey) 기준을 통일**
- 클러스터마다 “이 클러스터가 어느 위치에 있는지”를 기준으로 문자열 키를 하나 만들고, 그 키로 클러스터 배지 엔트리를 관리
- 현재 키는 클러스터 중심 좌표를 소수점 5자리로 고정한 문자열 - 예시: 37.12345,127.12345 (lat,lng 형태)
    - 해당 생성 로직을 build-cluster-key-from-center.ts 파일의 전역 유틸로 분리(kakao-map-view.ts에서 이미 사용중인 로직으로 중복되기에 분리함)

**2.  배지 엔트리 관리 기준을 overlay 객체 → clusterKey로 변경**
- 기존 CustomOverlay 인스턴스를 기준으로 배지 엔트리를 관리
- 하지만 clustered 재계산 과정에서 overlay 인스턴스가 교체될 수 있어, 동일 클러스터도 다른 것으로 인식되어 불필요한 정리/재생성이 발생
- 이를 방지하기 위해, 배지 엔트리를 overlay 인스턴스가 아닌 clusterKey(문자열 키) 기준으로 관리하도록 전환

**3.  overlay 교체 시 배지를 새로 만들지 않고 재부착하는 동작만 수행**
- 새 overlay에는 기존 배지 컨테이너를 setContent로 다시 재부착하여, 배지 엔트리의 unmount/remove → create/mount 반복을 차단

## 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->
- 클러스터 배지의 깜빡임 현상이 사라졌는지 확인
- clusterKey 생성 기준 충돌 가능성이 낮고 충분히 안정적인지 검토


## 추가 정보

<!-- 스크린샷, 테스트 방법 등 추가 정보가 있다면 작성하세요 -->

- 클러스터 마커 깜빡이는 현상 gif
![클러스터 마커 깜박임 문제](https://github.com/user-attachments/assets/cdf57d97-0932-4370-9b93-e85c9b666cf9)


- 클러스터 마커 깜빡이는 현상 해결 gif
![클러스터 마커 깜박임 해결](https://github.com/user-attachments/assets/86c4044f-b8eb-49d0-8832-f3a9143360cb)
