### PR TITLE
feat: sitemap, robots, JSON-LD 적용

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,15 +1,19 @@
+import { JsonLdScript } from '@/components/seo';
 import { createPageMetadata } from '@/utils';
+import { getHomeOrganizationJsonLd, getHomeWebsiteJsonLd, HOME_DESCRIPTION } from '@/utils/seo';
 import { HomeFooter, HomeHeroSection, HomePromoSection, HomeUpcomingBuskingSection } from './_components';
 
 export const metadata = createPageMetadata({
   title: 'HOME',
-  description: 'UNIBUSK에서 버스킹 공연 일정과 장소를 찾고, 다가오는 공연 정보를 확인해보세요.',
+  description: HOME_DESCRIPTION,
   path: '/',
 });
 
 export default function Page() {
   return (
     <main className="w-full">
+      <JsonLdScript id="website-json-ld" data={getHomeWebsiteJsonLd()} />
+      <JsonLdScript id="organization-json-ld" data={getHomeOrganizationJsonLd()} />
       <section className={`
         min-h-250 w-full
         bg-[radial-gradient(circle_at_center,#FAFAFA_0%,#FFF7F2CC_100%)]

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,4 +1,11 @@
+import { createPageMetadata } from '@/utils';
 import { HomeFooter, HomeHeroSection, HomePromoSection, HomeUpcomingBuskingSection } from './_components';
+
+export const metadata = createPageMetadata({
+  title: 'HOME',
+  description: 'UNIBUSK에서 버스킹 공연 일정과 장소를 찾고, 다가오는 공연 정보를 확인해보세요.',
+  path: '/',
+});
 
 export default function Page() {
   return (

--- a/src/app/(main)/performance-detail/[performanceId]/page.tsx
+++ b/src/app/(main)/performance-detail/[performanceId]/page.tsx
@@ -2,9 +2,12 @@ import type { Metadata } from 'next';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import { notFound } from 'next/navigation';
 import { cache, Suspense } from 'react';
+import { Header } from '@/components/common/header';
+import { JsonLdScript } from '@/components/seo';
 import { getQueryClient } from '@/queries';
 import { performanceDetailQueryOptions } from '@/queries/performance';
 import { createPageMetadata } from '@/utils';
+import { buildPerformanceBreadcrumbJsonLd, buildPerformanceEventJsonLd } from '@/utils/seo';
 import { Footer, PerformanceInfo } from './_components';
 
 const getPerformanceDetail = cache(async (performanceId: number) => {
@@ -56,6 +59,8 @@ export default async function PerformanceDetailPage(
   }
 
   const performanceDetail = await getPerformanceDetail(performanceId);
+  const eventJsonLd = buildPerformanceEventJsonLd(performanceId, performanceDetail);
+  const breadcrumbJsonLd = buildPerformanceBreadcrumbJsonLd(performanceId, performanceDetail.title);
 
   const queryClient = getQueryClient();
 
@@ -66,6 +71,8 @@ export default async function PerformanceDetailPage(
 
   return (
     <div className="relative container-1920 flex min-h-screen flex-col">
+      <JsonLdScript id="performance-event-json-ld" data={eventJsonLd} />
+      <JsonLdScript id="performance-breadcrumb-json-ld" data={breadcrumbJsonLd} />
       <main className="flex flex-1 flex-col">
         <HydrationBoundary state={dehydrate(queryClient)}>
           <Suspense fallback={<div>Loading...</div>}>

--- a/src/app/(main)/performance-detail/[performanceId]/page.tsx
+++ b/src/app/(main)/performance-detail/[performanceId]/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import { notFound } from 'next/navigation';
 import { cache, Suspense } from 'react';
-import { Header } from '@/components/common/header';
 import { JsonLdScript } from '@/components/seo';
 import { getQueryClient } from '@/queries';
 import { performanceDetailQueryOptions } from '@/queries/performance';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,9 @@ import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import localFont from 'next/font/local';
 import { Toaster } from '@/components/common/toast';
+import { SITE_URL } from '@/constants';
 import { QueryProvider } from '@/providers';
-import { ENV, SHARED_OPEN_GRAPH } from '@/utils';
+import { SHARED_OPEN_GRAPH } from '@/utils';
 import '../styles/globals.css';
 
 const pretendard = localFont({
@@ -14,7 +15,7 @@ const pretendard = localFont({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL(ENV.NEXT_PUBLIC_API_URL ?? 'https://unibusk.site'),
+  metadataBase: new URL(SITE_URL),
   title: {
     template: '%s | UNIBUSK',
     default: 'UNIBUSK',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import localFont from 'next/font/local';
 import { Toaster } from '@/components/common/toast';
 import { QueryProvider } from '@/providers';
-import { SHARED_OPEN_GRAPH } from '@/utils';
+import { ENV, SHARED_OPEN_GRAPH } from '@/utils';
 import '../styles/globals.css';
 
 const pretendard = localFont({
@@ -14,7 +14,7 @@ const pretendard = localFont({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_API_URL ?? 'https://unibusk.site'),
+  metadataBase: new URL(ENV.NEXT_PUBLIC_API_URL ?? 'https://unibusk.site'),
   title: {
     template: '%s | UNIBUSK',
     default: 'UNIBUSK',

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from 'next';
+import { ENV } from '@/utils';
+
+const SITE_URL = ENV.NEXT_PUBLIC_API_URL || 'https://unibusk.site';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/admin/'],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,7 +1,5 @@
 import type { MetadataRoute } from 'next';
-import { ENV } from '@/utils';
-
-const SITE_URL = ENV.NEXT_PUBLIC_API_URL || 'https://unibusk.site';
+import { SITE_URL } from '@/constants';
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,6 +6,10 @@ import { toAbsoluteUrl } from '@/utils/seo';
 
 export const revalidate = 3600;
 
+// API가 잘못된 페이지네이션 응답을 반환해도 사이트맵 생성이 무한 루프에 빠지지 않도록 최대 페이지 수를 제한
+// 추후 최대 공연 수에 따라 변동
+const MAX_PERFORMANCE_PAGES = 200;
+
 const STATIC_PAGES: Array<{
   path: string;
   changeFrequency: NonNullable<MetadataRoute.Sitemap[number]['changeFrequency']>;
@@ -21,7 +25,7 @@ async function getPerformanceIds(type: PerformanceFilterTab): Promise<number[]> 
   const performanceIds: number[] = [];
   let page = 0;
 
-  while (true) {
+  while (page < MAX_PERFORMANCE_PAGES) {
     const { content, hasNext } = await getPerformanceList(type, page, {
       skipRedirectOn401: true,
     });
@@ -32,12 +36,21 @@ async function getPerformanceIds(type: PerformanceFilterTab): Promise<number[]> 
       return performanceIds;
     }
 
+    if (content.length === 0) {
+      console.warn(`사이트맵: ${type} ${page} 페이지 응답이 비어 있어 순회를 중단`);
+      return performanceIds;
+    }
+
     page += 1;
   }
+
+  // 변경: 최대 페이지 상한에 도달한 경우에도 현재까지 수집한 ID로 사이트맵 생성
+  console.warn(`사이트맵: ${type} 페이지 상한(${MAX_PERFORMANCE_PAGES})에 도달함`);
+  return performanceIds;
 }
 
 function getUniqueValues<TValue>(values: TValue[]): TValue[] {
-  return values.filter((value, index) => values.indexOf(value) === index);
+  return Array.from(new Set(values));
 }
 
 async function getPerformanceIdsSafely(): Promise<number[]> {
@@ -75,8 +88,6 @@ async function getPerformanceDetailEntries(): Promise<MetadataRoute.Sitemap> {
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  // 현재 sitemap 생성 시각입니다.
-  // 지금은 모든 엔트리에 공통으로 넣고, 추후에는 페이지별 실제 수정 시각으로 고도화할 수 있습니다.
   const lastModified = new Date();
   const performanceDetailEntries = await getPerformanceDetailEntries();
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,7 +4,7 @@ import { getPerformanceList } from '@/apis/performance';
 import { routePaths } from '@/utils';
 import { toAbsoluteUrl } from '@/utils/seo';
 
-export const revalidate = 60 * 60;
+export const revalidate = 3600;
 
 const STATIC_PAGES: Array<{
   path: string;

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -36,12 +36,31 @@ async function getPerformanceIds(type: PerformanceFilterTab): Promise<number[]> 
   }
 }
 
+function getUniqueValues<TValue>(values: TValue[]): TValue[] {
+  return values.filter((value, index) => values.indexOf(value) === index);
+}
+
+async function getPerformanceIdsSafely(): Promise<number[]> {
+  const performanceIdResults = await Promise.allSettled([
+    getPerformanceIds('upcoming'),
+    getPerformanceIds('past'),
+  ]);
+
+  const performanceIds = performanceIdResults.flatMap((result) => {
+    if (result.status === 'rejected') {
+      console.error('사이트맵 생성 중 공연 ID 조회에 실패했습니다.', result.reason);
+      return [];
+    }
+
+    return result.value;
+  });
+
+  return getUniqueValues(performanceIds);
+}
+
 async function getPerformanceDetailEntries(): Promise<MetadataRoute.Sitemap> {
   try {
-    const performanceIds = await Promise.all([
-      getPerformanceIds('upcoming'),
-      getPerformanceIds('past'),
-    ]).then(results => [...new Set(results.flat())]);
+    const performanceIds = await getPerformanceIdsSafely();
 
     return performanceIds.map(performanceId => ({
       url: toAbsoluteUrl(routePaths.performanceDetail(performanceId)),
@@ -50,7 +69,7 @@ async function getPerformanceDetailEntries(): Promise<MetadataRoute.Sitemap> {
     }));
   }
   catch (error) {
-    console.error('Failed to build performance detail entries for sitemap.', error);
+    console.error('사이트맵 생성 중 공연 상세 URL 목록 생성에 실패했습니다.', error);
     return [];
   }
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,80 @@
+import type { MetadataRoute } from 'next';
+import type { PerformanceFilterTab } from '@/types/performance';
+import { getPerformanceList } from '@/apis/performance';
+import { ENV, routePaths } from '@/utils';
+
+export const revalidate = 60 * 60;
+
+const SITE_URL = ENV.NEXT_PUBLIC_API_URL || 'https://unibusk.site';
+
+const STATIC_PAGES: Array<{
+  path: string;
+  changeFrequency: NonNullable<MetadataRoute.Sitemap[number]['changeFrequency']>;
+  priority: number;
+}> = [
+  { path: '/', changeFrequency: 'daily', priority: 1 },
+  { path: '/about-us', changeFrequency: 'monthly', priority: 0.7 },
+  { path: '/performance-list', changeFrequency: 'daily', priority: 0.9 },
+  { path: '/busking-map', changeFrequency: 'daily', priority: 0.8 },
+];
+
+function toAbsoluteUrl(path: string) {
+  return new URL(path, SITE_URL).toString();
+}
+
+async function getPerformanceIds(type: PerformanceFilterTab): Promise<number[]> {
+  const performanceIds: number[] = [];
+  let page = 0;
+
+  while (true) {
+    const { content, hasNext } = await getPerformanceList(type, page, {
+      skipRedirectOn401: true,
+    });
+
+    performanceIds.push(...content.map(({ performanceId }) => performanceId));
+
+    if (!hasNext) {
+      return performanceIds;
+    }
+
+    page += 1;
+  }
+}
+
+async function getPerformanceDetailEntries(): Promise<MetadataRoute.Sitemap> {
+  try {
+    const performanceIds = await Promise.all([
+      getPerformanceIds('upcoming'),
+      getPerformanceIds('past'),
+    ]).then(results => [...new Set(results.flat())]);
+
+    return performanceIds.map(performanceId => ({
+      url: toAbsoluteUrl(routePaths.performanceDetail(performanceId)),
+      changeFrequency: 'weekly',
+      priority: 0.6,
+    }));
+  }
+  catch (error) {
+    console.error('Failed to build performance detail entries for sitemap.', error);
+    return [];
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // 현재 sitemap 생성 시각입니다.
+  // 지금은 모든 엔트리에 공통으로 넣고, 추후에는 페이지별 실제 수정 시각으로 고도화할 수 있습니다.
+  const lastModified = new Date();
+  const performanceDetailEntries = await getPerformanceDetailEntries();
+
+  return [
+    ...STATIC_PAGES.map(({ path, ...metadata }) => ({
+      url: toAbsoluteUrl(path),
+      lastModified,
+      ...metadata,
+    })),
+    ...performanceDetailEntries.map(entry => ({
+      ...entry,
+      lastModified,
+    })),
+  ];
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,11 +1,10 @@
 import type { MetadataRoute } from 'next';
 import type { PerformanceFilterTab } from '@/types/performance';
 import { getPerformanceList } from '@/apis/performance';
-import { ENV, routePaths } from '@/utils';
+import { routePaths } from '@/utils';
+import { toAbsoluteUrl } from '@/utils/seo';
 
 export const revalidate = 60 * 60;
-
-const SITE_URL = ENV.NEXT_PUBLIC_API_URL || 'https://unibusk.site';
 
 const STATIC_PAGES: Array<{
   path: string;
@@ -17,10 +16,6 @@ const STATIC_PAGES: Array<{
   { path: '/performance-list', changeFrequency: 'daily', priority: 0.9 },
   { path: '/busking-map', changeFrequency: 'daily', priority: 0.8 },
 ];
-
-function toAbsoluteUrl(path: string) {
-  return new URL(path, SITE_URL).toString();
-}
 
 async function getPerformanceIds(type: PerformanceFilterTab): Promise<number[]> {
   const performanceIds: number[] = [];

--- a/src/components/seo/index.ts
+++ b/src/components/seo/index.ts
@@ -1,0 +1,1 @@
+export { JsonLdScript } from './json-ld-script';

--- a/src/components/seo/json-ld-script.tsx
+++ b/src/components/seo/json-ld-script.tsx
@@ -1,0 +1,20 @@
+import type { Thing, WithContext } from 'schema-dts';
+
+/* eslint-disable react-dom/no-dangerously-set-innerhtml -- JSON-LD must be rendered as raw JSON in a script tag. */
+
+interface JsonLdScriptProps {
+  data: WithContext<Thing>;
+  id?: string;
+}
+
+export function JsonLdScript({ data, id }: JsonLdScriptProps) {
+  return (
+    <script
+      id={id}
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, '\\u003c'),
+      }}
+    />
+  );
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,2 @@
 export { ROUTES } from './routes';
+export { SITE_URL } from './site';

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -1,1 +1,3 @@
-export const SITE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://unibusk.site';
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_API_URL || 'https://unibusk.site'
+).replace(/\/+$/, '');

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -1,0 +1,1 @@
+export const SITE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://unibusk.site';

--- a/src/utils/seo/home-json-ld.ts
+++ b/src/utils/seo/home-json-ld.ts
@@ -1,0 +1,27 @@
+import type { Organization, WebSite, WithContext } from 'schema-dts';
+import { SITE_URL } from '@/constants';
+import { toAbsoluteUrl } from './site-url';
+
+export const HOME_DESCRIPTION = 'UNIBUSK에서 버스킹 공연 일정과 장소를 찾고, 다가오는 공연 정보를 확인해보세요.';
+
+export function getHomeWebsiteJsonLd(): WithContext<WebSite> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    'name': 'UNIBUSK',
+    'url': SITE_URL,
+    'description': HOME_DESCRIPTION,
+    'inLanguage': 'ko-KR',
+  };
+}
+
+export function getHomeOrganizationJsonLd(): WithContext<Organization> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    'name': 'UNIBUSK',
+    'url': SITE_URL,
+    'logo': toAbsoluteUrl('/logos/logo-unibusk-stacked-vertical.png'),
+    'description': '공연이 만들어지고, 보여지고, 시작되는 곳. 버스킹의 모든 순간을 잇다, UNIBUSK',
+  };
+}

--- a/src/utils/seo/index.ts
+++ b/src/utils/seo/index.ts
@@ -1,0 +1,3 @@
+export { getHomeOrganizationJsonLd, getHomeWebsiteJsonLd, HOME_DESCRIPTION } from './home-json-ld';
+export { buildPerformanceBreadcrumbJsonLd, buildPerformanceEventJsonLd } from './performance-json-ld';
+export { toAbsoluteUrl } from './site-url';

--- a/src/utils/seo/performance-json-ld.ts
+++ b/src/utils/seo/performance-json-ld.ts
@@ -1,0 +1,91 @@
+import type { BreadcrumbList, Event, ListItem, WithContext } from 'schema-dts';
+import type { PerformanceDetailResponseDto } from '@/apis/performance';
+import { SITE_URL } from '@/constants';
+import { routePaths } from '../route-paths';
+import { toAbsoluteUrl } from './site-url';
+
+function toKstDateTime(date: string, time: string) {
+  return `${date}T${time}:00+09:00`;
+}
+
+function toAbsoluteImageUrl(imageUrl: string) {
+  if (/^https?:\/\//.test(imageUrl)) {
+    return imageUrl;
+  }
+
+  return toAbsoluteUrl(imageUrl);
+}
+
+export function buildPerformanceEventJsonLd(
+  performanceId: number,
+  performanceDetail: PerformanceDetailResponseDto,
+): WithContext<Event> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    'name': performanceDetail.title,
+    'description': performanceDetail.summary || performanceDetail.description,
+    'url': toAbsoluteUrl(routePaths.performanceDetail(performanceId)),
+    'startDate': toKstDateTime(performanceDetail.performanceDate, performanceDetail.startTime),
+    'endDate': toKstDateTime(performanceDetail.performanceDate, performanceDetail.endTime),
+    'eventAttendanceMode': 'https://schema.org/OfflineEventAttendanceMode',
+    'eventStatus': 'https://schema.org/EventScheduled',
+    'inLanguage': 'ko-KR',
+    ...(performanceDetail.images.length > 0 && {
+      image: performanceDetail.images.map(toAbsoluteImageUrl),
+    }),
+    'location': {
+      '@type': 'Place',
+      'name': performanceDetail.locationName,
+      'address': performanceDetail.address,
+      'geo': {
+        '@type': 'GeoCoordinates',
+        'latitude': performanceDetail.latitude,
+        'longitude': performanceDetail.longitude,
+      },
+    },
+    ...(performanceDetail.performers.length > 0 && {
+      performer: performanceDetail.performers.map(performer => ({
+        '@type': 'Person',
+        'name': performer.name,
+      })),
+    }),
+    'organizer': {
+      '@type': 'Organization',
+      'name': 'UNIBUSK',
+      'url': SITE_URL,
+    },
+  };
+}
+
+export function buildPerformanceBreadcrumbJsonLd(
+  performanceId: number,
+  title: string,
+): WithContext<BreadcrumbList> {
+  const itemListElement: ListItem[] = [
+    {
+      '@type': 'ListItem',
+      'position': 1,
+      'name': '홈',
+      'item': SITE_URL,
+    },
+    {
+      '@type': 'ListItem',
+      'position': 2,
+      'name': '공연 정보',
+      'item': toAbsoluteUrl('/performance-list'),
+    },
+    {
+      '@type': 'ListItem',
+      'position': 3,
+      'name': title,
+      'item': toAbsoluteUrl(routePaths.performanceDetail(performanceId)),
+    },
+  ];
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    'itemListElement': itemListElement,
+  };
+}

--- a/src/utils/seo/performance-json-ld.ts
+++ b/src/utils/seo/performance-json-ld.ts
@@ -4,22 +4,35 @@ import { SITE_URL } from '@/constants';
 import { routePaths } from '../route-paths';
 import { toAbsoluteUrl } from './site-url';
 
+const HTTP_URL_PATTERN = /^https?:\/\//i;
+const PROTOCOL_RELATIVE_URL_PATTERN = /^\/\//;
+
 function toKstDateTime(date: string, time: string) {
   return `${date}T${time}:00+09:00`;
 }
 
 function toAbsoluteImageUrl(imageUrl: string) {
-  if (/^https?:\/\//.test(imageUrl)) {
-    return imageUrl;
+  const normalizedImageUrl = imageUrl.trim();
+
+  if (HTTP_URL_PATTERN.test(normalizedImageUrl)) {
+    return normalizedImageUrl;
   }
 
-  return toAbsoluteUrl(imageUrl);
+  if (PROTOCOL_RELATIVE_URL_PATTERN.test(normalizedImageUrl)) {
+    return `https:${normalizedImageUrl}`;
+  }
+
+  return toAbsoluteUrl(normalizedImageUrl);
 }
 
 export function buildPerformanceEventJsonLd(
   performanceId: number,
   performanceDetail: PerformanceDetailResponseDto,
 ): WithContext<Event> {
+  const imageUrls = performanceDetail.images
+    .filter(imageUrl => imageUrl.trim().length > 0)
+    .map(toAbsoluteImageUrl);
+
   return {
     '@context': 'https://schema.org',
     '@type': 'Event',
@@ -31,8 +44,8 @@ export function buildPerformanceEventJsonLd(
     'eventAttendanceMode': 'https://schema.org/OfflineEventAttendanceMode',
     'eventStatus': 'https://schema.org/EventScheduled',
     'inLanguage': 'ko-KR',
-    ...(performanceDetail.images.length > 0 && {
-      image: performanceDetail.images.map(toAbsoluteImageUrl),
+    ...(imageUrls.length > 0 && {
+      image: imageUrls,
     }),
     'location': {
       '@type': 'Place',

--- a/src/utils/seo/site-url.ts
+++ b/src/utils/seo/site-url.ts
@@ -1,0 +1,5 @@
+import { SITE_URL } from '@/constants';
+
+export function toAbsoluteUrl(path: string) {
+  return new URL(path, SITE_URL).toString();
+}


### PR DESCRIPTION
## 관련 이슈

<!-- 이슈 번호를 입력하세요. -->

Closes #170 

## 변경사항

<!-- 주요 변경사항을 작성하세요. -->

### 1. sitemap.ts 추가
  - 홈, 회사 소개, 공연 일정, 버스킹 맵, 공연 상세 페이지를 sitemap에 포함
  - 공연 목록 API를 순회해 공연 상세 URL을 동적으로 생성
  - sitemap 엔트리에 lastModified 메타데이터 추가

### 2. robots.ts 추가
  - 전체 공개 페이지 크롤링 허용
  - /api, /admin 경로 크롤링 제외
  - sitemap 경로 연결

### 3.  JSON-LD 공통 컴포넌트 추가
  - application/ld+json 스크립트 출력을 위한 공통 JsonLdScript 컴포넌트 추가

### 4.  홈 JSON-LD 적용
  - WebSite JSON-LD 추가
  - Organization JSON-LD 추가

### 5. 공연 상세 JSON-LD 적용
  - Event JSON-LD 추가
  - BreadcrumbList JSON-LD 추가

### 6.  SEO 유틸 분리
  - 홈/공연 상세 구조화 데이터 생성 유틸 분리
  - URL 생성 유틸 분리


## 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->
- sitemap.xml에 공개 페이지와 공연 상세 URL이 의도대로 포함되는지 체크
- 홈 페이지에 WebSite / Organization JSON-LD가 올바르게 나오는지 확인
- 공연 상세 페이지에 Event / BreadcrumbList JSON-LD가 정상 출력되는지 확인

## 추가 정보

<!-- 스크린샷, 테스트 방법 등 추가 정보가 있다면 작성하세요 -->
- /sitemap.xml 정상 노출 확인 필요
- /robots.txt 정상 노출 확인 필요