### PR TITLE
feat: 내 공연 목록 조회 페이지 구현

### DIFF
--- a/src/apis/performance/index.ts
+++ b/src/apis/performance/index.ts
@@ -1,5 +1,6 @@
 export {
   createPerformance,
+  getMyPerformances,
   getPastPerformancesByLocation,
   getPerformanceDetail,
   getPerformanceList,
@@ -9,6 +10,8 @@ export {
 } from './performance.api';
 export { transformPerformanceFormToApiRequest } from './performance.lib';
 export type {
+  MyPerformanceCursorResponse,
+  MyPerformanceSummary,
   PerformanceDetailResponseDto,
   PerformanceListResponseDto,
   PerformanceRegisterForm,

--- a/src/apis/performance/index.ts
+++ b/src/apis/performance/index.ts
@@ -1,5 +1,6 @@
 export {
   createPerformance,
+  deletePerformance,
   getMyPerformances,
   getPastPerformancesByLocation,
   getPerformanceDetail,

--- a/src/apis/performance/performance.api.ts
+++ b/src/apis/performance/performance.api.ts
@@ -4,7 +4,7 @@ import type { PerformanceFilterTab } from '@/types/performance';
 import { api } from '../api.instance';
 import { parseResponse } from '../api.parse';
 import {
-
+  MyPerformanceCursorResponseSchema,
   performanceByLocationCursorSchema,
   PerformanceDetailResponseDtoSchema,
   PerformanceListResponseDtoSchema,
@@ -126,4 +126,24 @@ export function getUpcomingPerformancePreview(config?: FetchConfig) {
   return api
     .get('/api/performances/upcoming/preview', { ...config })
     .then(parseResponse(PerformanceUpcomingPreviewResponseDtoSchema));
+}
+
+/**
+ * 내 공연 목록 조회 (커서 기반 페이지네이션)
+ * @param cursorId - 다음 페이지 커서 ID (첫 요청 시 undefined)
+ * @param size - 조회 개수 (기본값 10)
+ */
+export function getMyPerformances(
+  cursorId?: number,
+  size = 10,
+  config?: FetchConfig,
+) {
+  const params: Record<string, string> = { size: String(size) };
+  if (cursorId !== undefined) {
+    params.cursorId = String(cursorId);
+  }
+
+  return api
+    .get('/api/performances/me', { ...config, params })
+    .then(parseResponse(MyPerformanceCursorResponseSchema));
 }

--- a/src/apis/performance/performance.api.ts
+++ b/src/apis/performance/performance.api.ts
@@ -147,3 +147,11 @@ export function getMyPerformances(
     .get('/api/performances/me', { ...config, params })
     .then(parseResponse(MyPerformanceCursorResponseSchema));
 }
+
+/**
+ * 내 공연 삭제
+ * @param performanceId - 삭제할 공연 ID
+ */
+export function deletePerformance(performanceId: number, config?: FetchConfig) {
+  return api.delete<void>(`/api/performances/${performanceId}`, config);
+}

--- a/src/apis/performance/performance.schema.ts
+++ b/src/apis/performance/performance.schema.ts
@@ -206,3 +206,25 @@ export type PerformanceUpcomingPreviewItemDto = z.infer<
 export type PerformanceUpcomingPreviewResponseDto = z.infer<
   typeof PerformanceUpcomingPreviewResponseDtoSchema
 >;
+
+// 내 공연 목록 아이템 스키마
+export const MyPerformanceSummarySchema = z.object({
+  performanceId: z.number(),
+  memberId: z.number(),
+  title: z.string(),
+  startTime: z.string(), // ISO 8601 그대로 유지 (date-fns format 사용)
+  endTime: z.string(),
+  performanceLocationName: z.string(),
+  imageUrls: z.array(z.string()).default([]),
+});
+
+// 내 공연 목록 커서 응답 스키마
+export const MyPerformanceCursorResponseSchema = z.object({
+  content: z.array(MyPerformanceSummarySchema),
+  nextCursorId: z.number().nullable(),
+  nextCursorTime: z.string().nullable(),
+  hasNext: z.boolean(),
+});
+
+export type MyPerformanceSummary = z.infer<typeof MyPerformanceSummarySchema>;
+export type MyPerformanceCursorResponse = z.infer<typeof MyPerformanceCursorResponseSchema>;

--- a/src/app/performance-list/_components/hero.tsx
+++ b/src/app/performance-list/_components/hero.tsx
@@ -1,26 +1,10 @@
 'use client';
 
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
-import { Button } from '@/components/common/button';
-import { RegisterModal } from '@/components/performance';
-import { useAuth } from '@/hooks';
-import { cn, routePaths } from '@/utils';
+import { PerformanceRegisterButton } from '@/components/performance';
+import { cn } from '@/utils';
 
 export function Hero() {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const { isAuthenticated } = useAuth();
-  const router = useRouter();
-
-  const handleRegisterClick = () => {
-    if (!isAuthenticated) {
-      router.push(routePaths.login());
-      return;
-    }
-    setIsModalOpen(true);
-  };
-
   return (
     <section
       className={cn(`
@@ -51,19 +35,10 @@ export function Hero() {
           <span className="block">나의 공연 정보를</span>
           <span className="block">등록하고 홍보해 보세요</span>
         </h2>
-        <Button
-          theme="orange"
-          size="lg"
-          appearance="filled"
-          onClick={handleRegisterClick}
-        >
+        <PerformanceRegisterButton theme="orange" size="lg" appearance="filled">
           공연 등록하기
-        </Button>
+        </PerformanceRegisterButton>
       </div>
-      <RegisterModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-      />
     </section>
   );
 }

--- a/src/app/profile/_components/profile-info.tsx
+++ b/src/app/profile/_components/profile-info.tsx
@@ -1,20 +1,19 @@
 'use client';
 
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Button } from '@/components/common/button';
 import { AvatarCircleIcon } from '@/components/common/icon';
+import { userQueryOptions } from '@/queries/user/user.query';
 import { cn } from '@/utils';
-
-interface ProfileInfoProps {
-  email: string;
-  name: string;
-}
 
 interface DisplayInputProps {
   label: string;
   value?: string | number;
 }
 
-export function ProfileInfo({ email, name }: ProfileInfoProps) {
+export function ProfileInfo() {
+  const { data: { email, name } } = useSuspenseQuery(userQueryOptions);
+
   return (
     <section className="flex w-full flex-col items-center gap-16.75">
       {/* 아바타 아이콘 */}

--- a/src/app/profile/_components/profile-performances.tsx
+++ b/src/app/profile/_components/profile-performances.tsx
@@ -6,7 +6,7 @@ import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Spinner } from '@/components/common/spinner';
 import { PerformanceRegisterButton } from '@/components/performance';
 import { myPerformancesInfiniteQueryOptions } from '@/queries/performance/performance.query';
@@ -124,6 +124,7 @@ function MyPerformanceCard({
   performanceLocationName,
   imageUrls,
 }: MyPerformanceCardProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { date, time } = formatPerformanceTime(startTime, endTime);
   const thumbnailSrc = imageUrls[0];
 
@@ -153,20 +154,107 @@ function MyPerformanceCard({
           {/* 상단: 제목 + 더보기 */}
           <div className="flex items-center justify-between">
             <h3 className="typo-body-sb-1 text-black">{title}</h3>
-            <button
-              type="button"
-              aria-label="더보기"
-              className="flex shrink-0 items-center justify-center"
+            <div
+              className="relative"
+              onBlurCapture={(event) => {
+                const nextTarget = event.relatedTarget;
+                if (!(nextTarget instanceof Node)) {
+                  setIsMenuOpen(false);
+                  return;
+                }
+                if (!event.currentTarget.contains(nextTarget)) {
+                  setIsMenuOpen(false);
+                }
+              }}
             >
-              <Image
-                src="/icons/ellipsisVertical.svg"
-                alt=""
-                width={5}
-                height={21}
-                aria-hidden="true"
-                unoptimized
-              />
-            </button>
+              <button
+                type="button"
+                aria-label="더보기"
+                aria-haspopup="menu"
+                aria-expanded={isMenuOpen}
+                className={`
+                  flex shrink-0 cursor-pointer items-center justify-center
+                  rounded-full p-1.5 transition-colors
+                  hover:bg-gray-100
+                `}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setIsMenuOpen(prev => !prev);
+                }}
+              >
+                <Image
+                  src="/icons/ellipsisVertical.svg"
+                  alt=""
+                  width={30}
+                  height={30}
+                  aria-hidden="true"
+                  unoptimized
+                />
+              </button>
+
+              {isMenuOpen && (
+                <div
+                  role="menu"
+                  aria-label="더보기 메뉴"
+                  className={`
+                    absolute top-[calc(100%+8px)] right-0 z-dropdown w-30
+                    overflow-hidden rounded-[10px] bg-white
+                    shadow-[0_0_4px_rgba(0,0,0,0.25)]
+                  `}
+                >
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={`
+                      flex h-12.5 w-full cursor-pointer items-center gap-1.25
+                      border-b border-black/10 p-2.5 typo-caption-r-1 text-black
+                      transition-colors
+                      hover:bg-gray-100
+                    `}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setIsMenuOpen(false);
+                    }}
+                  >
+                    <Image
+                      src="/icons/pencilSquare.svg"
+                      alt=""
+                      width={19}
+                      height={19}
+                      aria-hidden="true"
+                      unoptimized
+                    />
+                    수정하기
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={`
+                      flex h-12.5 w-full cursor-pointer items-center gap-1.25
+                      p-2.5 typo-caption-r-1 text-black transition-colors
+                      hover:bg-gray-100
+                    `}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setIsMenuOpen(false);
+                    }}
+                  >
+                    <Image
+                      src="/icons/trashCan.svg"
+                      alt=""
+                      width={19}
+                      height={19}
+                      aria-hidden="true"
+                      unoptimized
+                    />
+                    삭제하기
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* 하단: 날짜/시간 + 장소 */}

--- a/src/app/profile/_components/profile-performances.tsx
+++ b/src/app/profile/_components/profile-performances.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link';
 import { useCallback, useRef, useState } from 'react';
 import { Spinner } from '@/components/common/spinner';
 import { PerformanceRegisterButton } from '@/components/performance';
+import { useDeletePerformance } from '@/hooks/performance';
 import { myPerformancesInfiniteQueryOptions } from '@/queries/performance/performance.query';
 import { routePaths } from '@/utils';
 
@@ -125,6 +126,7 @@ function MyPerformanceCard({
   imageUrls,
 }: MyPerformanceCardProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { mutate: deleteMyPerformance, isPending: isDeletePending } = useDeletePerformance();
   const { date, time } = formatPerformanceTime(startTime, endTime);
   const thumbnailSrc = imageUrls[0];
 
@@ -231,15 +233,18 @@ function MyPerformanceCard({
                   <button
                     type="button"
                     role="menuitem"
+                    disabled={isDeletePending}
                     className={`
                       flex h-12.5 w-full cursor-pointer items-center gap-1.25
                       p-2.5 typo-caption-r-1 text-black transition-colors
                       hover:bg-gray-100
+                      disabled:cursor-not-allowed disabled:opacity-50
                     `}
                     onClick={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
                       setIsMenuOpen(false);
+                      deleteMyPerformance(performanceId);
                     }}
                   >
                     <Image

--- a/src/app/profile/_components/profile-performances.tsx
+++ b/src/app/profile/_components/profile-performances.tsx
@@ -6,9 +6,18 @@ import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useCallback, useRef } from 'react';
+import { Spinner } from '@/components/common/spinner';
 import { PerformanceRegisterButton } from '@/components/performance';
 import { myPerformancesInfiniteQueryOptions } from '@/queries/performance/performance.query';
 import { routePaths } from '@/utils';
+
+interface PerformancesProps {
+  performances: MyPerformanceSummary[];
+  onLoadMore: () => void;
+  hasMore: boolean;
+  isLoading: boolean;
+}
 
 interface MyPerformanceCardProps {
   performanceId: number;
@@ -30,7 +39,8 @@ function formatPerformanceTime(startTime: string, endTime: string) {
 }
 
 export function ProfilePerformances() {
-  const { data } = useSuspenseInfiniteQuery(myPerformancesInfiniteQueryOptions());
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage }
+    = useSuspenseInfiniteQuery(myPerformancesInfiniteQueryOptions());
   const performances = data.pages.flatMap(page => page.content);
 
   return (
@@ -48,14 +58,39 @@ export function ProfilePerformances() {
               <PerformanceRegisterButton className="absolute -top-17.5 right-0" theme="lightGray" size="md">
                 내 공연 등록하기
               </PerformanceRegisterButton>
-              <Performances performances={performances} />
+              <Performances
+                performances={performances}
+                onLoadMore={fetchNextPage}
+                hasMore={!!hasNextPage}
+                isLoading={isFetchingNextPage}
+              />
             </>
           )}
     </div>
   );
 }
 
-function Performances({ performances }: { performances: MyPerformanceSummary[] }) {
+function Performances({ performances, onLoadMore, hasMore, isLoading }: PerformancesProps) {
+  const isLoadingRef = useRef(isLoading);
+  isLoadingRef.current = isLoading;
+
+  const sentinelCallbackRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node)
+      return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !isLoadingRef.current) {
+          onLoadMore();
+        }
+      },
+      { threshold: 0.5 },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [onLoadMore]);
+
   return (
     <section className="flex w-full flex-1 flex-col gap-7.5">
       {performances.map(performance => (
@@ -69,6 +104,14 @@ function Performances({ performances }: { performances: MyPerformanceSummary[] }
           imageUrls={performance.imageUrls}
         />
       ))}
+      {hasMore && (
+        <div
+          ref={sentinelCallbackRef}
+          className="flex h-20 items-center justify-center"
+        >
+          {isLoading && <Spinner className="size-6 text-gray-400" />}
+        </div>
+      )}
     </section>
   );
 }

--- a/src/app/profile/_components/profile-performances.tsx
+++ b/src/app/profile/_components/profile-performances.tsx
@@ -1,41 +1,179 @@
 'use client';
 
+import type { MyPerformanceSummary } from '@/apis/performance';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
 import Image from 'next/image';
-import { Button } from '@/components/common/button';
+import Link from 'next/link';
+import { PerformanceRegisterButton } from '@/components/performance';
+import { myPerformancesInfiniteQueryOptions } from '@/queries/performance/performance.query';
+import { routePaths } from '@/utils';
+
+interface MyPerformanceCardProps {
+  performanceId: number;
+  title: string;
+  startTime: string;
+  endTime: string;
+  performanceLocationName: string;
+  imageUrls: string[];
+}
+
+function formatPerformanceTime(startTime: string, endTime: string) {
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+
+  return {
+    date: format(start, 'yyyy년 MM월 dd일 (eee)', { locale: ko }),
+    time: `${format(start, 'HH:mm')} ~ ${format(end, 'HH:mm')}`,
+  };
+}
 
 export function ProfilePerformances() {
+  const { data } = useSuspenseInfiniteQuery(myPerformancesInfiniteQueryOptions());
+  const performances = data.pages.flatMap(page => page.content);
+
   return (
-    // 디자인 시안상 높이 정보가 없어 최소 높이를 지정하여 중앙 정렬 효과를 줍니다.
     <div className="flex w-full flex-1 flex-col">
-      <EmptyPerformances />
+      {performances.length === 0
+        ? (
+            <EmptyPerformances />
+          )
+        : (
+            <>
+              {/*
+            absolute 버튼: 이 div는 relative 없음
+            → 상위 profile-tab.tsx의 div.relative 기준으로 위치됨
+          */}
+              <PerformanceRegisterButton className="absolute -top-17.5 right-0" theme="lightGray" size="md">
+                내 공연 등록하기
+              </PerformanceRegisterButton>
+              <Performances performances={performances} />
+            </>
+          )}
     </div>
+  );
+}
+
+function Performances({ performances }: { performances: MyPerformanceSummary[] }) {
+  return (
+    <section className="flex w-full flex-1 flex-col gap-7.5">
+      {performances.map(performance => (
+        <MyPerformanceCard
+          key={performance.performanceId}
+          performanceId={performance.performanceId}
+          title={performance.title}
+          startTime={performance.startTime}
+          endTime={performance.endTime}
+          performanceLocationName={performance.performanceLocationName}
+          imageUrls={performance.imageUrls}
+        />
+      ))}
+    </section>
+  );
+}
+
+function MyPerformanceCard({
+  performanceId,
+  title,
+  startTime,
+  endTime,
+  performanceLocationName,
+  imageUrls,
+}: MyPerformanceCardProps) {
+  const { date, time } = formatPerformanceTime(startTime, endTime);
+  const thumbnailSrc = imageUrls[0];
+
+  return (
+    <Link href={routePaths.performanceDetail(performanceId)}>
+      <div className={`
+        flex w-full items-center rounded-lg bg-white p-2.5 shadow-elevate-2
+      `}
+      >
+        {/* 썸네일 */}
+        <div className={`
+          relative h-45 w-37.5 shrink-0 overflow-hidden rounded-lg bg-gray-300
+        `}
+        >
+          {thumbnailSrc && (
+            <Image
+              src={thumbnailSrc}
+              alt={title}
+              fill
+              className="object-cover"
+            />
+          )}
+        </div>
+
+        {/* 콘텐츠 */}
+        <div className="flex h-45 flex-1 flex-col justify-center gap-7.5 px-10">
+          {/* 상단: 제목 + 더보기 */}
+          <div className="flex items-center justify-between">
+            <h3 className="typo-body-sb-1 text-black">{title}</h3>
+            <button
+              type="button"
+              aria-label="더보기"
+              className="flex shrink-0 items-center justify-center"
+            >
+              <Image
+                src="/icons/ellipsisVertical.svg"
+                alt=""
+                width={5}
+                height={21}
+                aria-hidden="true"
+                unoptimized
+              />
+            </button>
+          </div>
+
+          {/* 하단: 날짜/시간 + 장소 */}
+          <div className="flex flex-col gap-1.25">
+            <div className="typo-caption-m-1 text-gray-700">
+              <p>{date}</p>
+              <p>{time}</p>
+            </div>
+            <div className="flex items-center gap-1.25">
+              <Image
+                src="/icons/mapPin.svg"
+                alt=""
+                width={10}
+                height={14}
+                aria-hidden="true"
+                unoptimized
+              />
+              <p className="typo-caption-m-1 text-gray-700">
+                {performanceLocationName}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Link>
   );
 }
 
 function EmptyPerformances() {
   return (
-    <section className={`
-      flex w-full flex-1 flex-col items-center justify-center gap-2.5
-    `}
-    >
-      <div className="flex flex-col items-center justify-center gap-2.5">
-        <Image
-          src="/icons/bangCircle-gray.svg"
-          alt=""
-          width={40}
-          height={40}
-          unoptimized={true}
-          aria-hidden="true"
-        />
-        <p className={`
-          flex flex-col items-center justify-center typo-body-m-3 text-gray-600
-        `}
-        >
-          현재 지원하지 않는 페이지입니다.
-        </p>
-        <Button theme="lightGray">홈으로 돌아가기</Button>
+    <section className="flex w-full flex-1 flex-col items-center justify-center">
+      <div className="flex flex-col items-center gap-6">
+        <div className="flex flex-col items-center gap-2.5">
+          <Image
+            src="/icons/bangCircle-gray.svg"
+            alt=""
+            width={40}
+            height={40}
+            unoptimized
+            aria-hidden="true"
+          />
+          <div className="flex flex-col items-center gap-1.25">
+            <p className="typo-body-m-3 text-gray-600">등록한 공연이 없습니다.</p>
+            <p className="typo-caption-r-1 text-gray-600">나의 공연을 등록하고 홍보해 보세요!</p>
+          </div>
+        </div>
+        <PerformanceRegisterButton theme="lightGray" size="md">
+          내 공연 등록하기
+        </PerformanceRegisterButton>
       </div>
-
     </section>
   );
 }

--- a/src/app/profile/_components/profile-performances.tsx
+++ b/src/app/profile/_components/profile-performances.tsx
@@ -147,6 +147,7 @@ function MyPerformanceCard({
               alt={title}
               fill
               className="object-cover"
+              sizes="150px"
             />
           )}
         </div>
@@ -272,7 +273,7 @@ function MyPerformanceCard({
               <Image
                 src="/icons/mapPin.svg"
                 alt=""
-                width={10}
+                width={14}
                 height={14}
                 aria-hidden="true"
                 unoptimized

--- a/src/app/profile/_components/profile-tab.tsx
+++ b/src/app/profile/_components/profile-tab.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/common/tags/tabs';
-import { userQueryOptions } from '@/queries/user/user.query';
 import { cn } from '@/utils';
 import { ProfileInfo } from './profile-info';
 import { ProfilePerformances } from './profile-performances';
@@ -22,32 +21,43 @@ export function ProfileTab() {
 }
 
 function BaseProfileTab() {
-  const { data: { email, name } }
-    = useSuspenseQuery(userQueryOptions);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const rawTab = searchParams.get('tab');
+  const activeTab: 'my-info' | 'my-performances'
+    = rawTab === 'my-performances' ? 'my-performances' : 'my-info';
+
+  const handleTabChange = (value: string) => {
+    router.replace(`${pathname}?tab=${value}`);
+  };
 
   return (
     <div className="flex w-full flex-1 flex-col pt-21.25">
 
-      <Tabs
-        defaultValue="my-info"
-        className="flex min-h-[500px] flex-1 flex-row gap-6"
-      >
+      {/* 타이틀: TabsList 밖으로 분리 → 탭 트리거 y=0 기준점 확보 */}
+      <h1 className="mb-25 pl-5 typo-title-sb-2 text-black">마이페이지</h1>
 
+      <Tabs
+        value={activeTab}
+        onValueChange={handleTabChange}
+        className="flex min-h-125 flex-1 flex-row gap-11"
+      >
+        {/* 좌: 탭 트리거 — y=0 기준 */}
         <TabsList className="mb-0 h-full w-55 flex-col bg-transparent p-0">
-          <h1 className="mb-25 typo-title-sb-2 text-black">마이페이지</h1>
-          <div className="m-auto flex h-30 w-full flex-col gap-5 px-5">
+          <div className="flex w-full flex-col gap-5 px-5">
             <ProfileTabTrigger filter="my-info" content="내 정보" />
             <ProfileTabTrigger filter="my-performances" content="내가 등록한 공연" />
           </div>
-
         </TabsList>
 
-        <div className="flex flex-1 flex-col">
+        <div className="relative flex flex-1 flex-col">
           <TabsContent
             value="my-info"
             className="mt-0 flex flex-1 outline-none"
           >
-            <ProfileInfo email={email} name={name} />
+            <ProfileInfo />
           </TabsContent>
 
           <TabsContent

--- a/src/app/profile/_components/profile-tab.tsx
+++ b/src/app/profile/_components/profile-tab.tsx
@@ -30,7 +30,9 @@ function BaseProfileTab() {
     = rawTab === 'my-performances' ? 'my-performances' : 'my-info';
 
   const handleTabChange = (value: string) => {
-    router.replace(`${pathname}?tab=${value}`);
+    const params = new URLSearchParams(searchParams);
+    params.set('tab', value); // tab만 덮어쓰기
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
   return (

--- a/src/components/performance/index.ts
+++ b/src/components/performance/index.ts
@@ -1,1 +1,2 @@
+export { PerformanceRegisterButton } from './performance-register-button';
 export { RegisterModal } from './register-modal';

--- a/src/components/performance/performance-register-button.tsx
+++ b/src/components/performance/performance-register-button.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { Button } from '@/components/common/button';
+import { useAuth } from '@/hooks';
+import { routePaths } from '@/utils';
+import { RegisterModal } from './register-modal';
+
+type PerformanceRegisterButtonProps = ComponentProps<typeof Button>;
+
+export function PerformanceRegisterButton({
+  children,
+  onClick,
+  ...buttonProps
+}: PerformanceRegisterButtonProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { isAuthenticated } = useAuth();
+  const router = useRouter();
+
+  const handleClick: ComponentProps<typeof Button>['onClick'] = (e) => {
+    onClick?.(e);
+    if (!isAuthenticated) {
+      router.push(routePaths.login());
+      return;
+    }
+    setIsModalOpen(true);
+  };
+
+  return (
+    <>
+      <Button {...buttonProps} onClick={handleClick}>
+        {children}
+      </Button>
+      <RegisterModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
+    </>
+  );
+}

--- a/src/components/performance/performance-register-button.tsx
+++ b/src/components/performance/performance-register-button.tsx
@@ -13,14 +13,20 @@ type PerformanceRegisterButtonProps = ComponentProps<typeof Button>;
 export function PerformanceRegisterButton({
   children,
   onClick,
+  disabled,
   ...buttonProps
 }: PerformanceRegisterButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isPending } = useAuth();
   const router = useRouter();
 
   const handleClick: ComponentProps<typeof Button>['onClick'] = (e) => {
     onClick?.(e);
+
+    if (e.defaultPrevented || isPending) {
+      return;
+    }
+
     if (!isAuthenticated) {
       router.push(routePaths.login());
       return;
@@ -30,7 +36,7 @@ export function PerformanceRegisterButton({
 
   return (
     <>
-      <Button {...buttonProps} onClick={handleClick}>
+      <Button {...buttonProps} disabled={disabled || isPending} onClick={handleClick}>
         {children}
       </Button>
       <RegisterModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />

--- a/src/hooks/performance/index.ts
+++ b/src/hooks/performance/index.ts
@@ -1,3 +1,4 @@
 export { useCreatePerformance } from './use-create-performance';
+export { useDeletePerformance } from './use-delete-performance';
 export { useLocationPerformances } from './use-location-performances';
 export { useUpcomingPerformancePreview } from './use-upcoming-performance-preview';

--- a/src/hooks/performance/use-create-performance.ts
+++ b/src/hooks/performance/use-create-performance.ts
@@ -12,8 +12,10 @@ export function useCreatePerformance() {
       return createPerformance(apiRequestData);
     },
     onSuccess: () => {
-      // 공연 목록 쿼리 무효화 (performanceKeys.lists() 사용)
+      // 공연 목록 쿼리 무효화
       queryClient.invalidateQueries({ queryKey: performanceKeys.lists() });
+      // 내 공연 목록 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: performanceKeys.myPerformances() });
     },
   });
 }

--- a/src/hooks/performance/use-delete-performance.ts
+++ b/src/hooks/performance/use-delete-performance.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deletePerformance } from '@/apis/performance';
+import { performanceKeys } from '@/queries/performance';
+
+export function useDeletePerformance() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (performanceId: number) => deletePerformance(performanceId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: performanceKeys.myPerformances() });
+    },
+  });
+}

--- a/src/queries/performance/performance.keys.ts
+++ b/src/queries/performance/performance.keys.ts
@@ -28,4 +28,7 @@ export const performanceKeys = {
 
   upcomingPreview: () => [...performanceKeys.all, 'upcoming', 'preview'] as const,
 
+  // 내 공연 목록
+  myPerformances: () => [...performanceKeys.all, 'my-performances'] as const,
+
 } as const;

--- a/src/queries/performance/performance.query.ts
+++ b/src/queries/performance/performance.query.ts
@@ -50,7 +50,7 @@ export function myPerformancesInfiniteQueryOptions() {
   return infiniteQueryOptions({
     queryKey: performanceKeys.myPerformances(),
     queryFn: async ({ pageParam, signal }) => {
-      return getMyPerformances(pageParam, 10, { signal });
+      return getMyPerformances(pageParam, 4, { signal });
     },
     initialPageParam: undefined as number | undefined,
     getNextPageParam: lastPage =>

--- a/src/queries/performance/performance.query.ts
+++ b/src/queries/performance/performance.query.ts
@@ -1,6 +1,6 @@
 import type { PerformanceFilterTab } from '@/types/performance';
 import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
-import { getPerformanceDetail, getPerformanceList, getSearchPerformanceList } from '@/apis/performance';
+import { getMyPerformances, getPerformanceDetail, getPerformanceList, getSearchPerformanceList } from '@/apis/performance';
 import { performanceKeys } from './performance.keys';
 
 /** 공연 목록 무한 스크롤 쿼리 옵션 */
@@ -42,5 +42,18 @@ export function performanceDetailQueryOptions(performanceId: number) {
     queryFn: async ({ signal }) => {
       return getPerformanceDetail(performanceId, { signal });
     },
+  });
+}
+
+/** 내 공연 목록 무한 스크롤 쿼리 옵션 (커서 기반) */
+export function myPerformancesInfiniteQueryOptions() {
+  return infiniteQueryOptions({
+    queryKey: performanceKeys.myPerformances(),
+    queryFn: async ({ pageParam, signal }) => {
+      return getMyPerformances(pageParam, 10, { signal });
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: lastPage =>
+      lastPage.hasNext ? (lastPage.nextCursorId ?? undefined) : undefined,
   });
 }


### PR DESCRIPTION
## 관련 이슈
Closes #173

## 변경사항

프로필의 내 공연 목록 탭을 구현했습니다.

### API 계층
- getMyPerformances: 커서 기반 페이지네이션 API
- deletePerformance: 공연 삭제 API
- useDeletePerformance: mutation hook

### UI 컴포넌트
- MyPerformanceCard: 썸네일, 제목, 날짜, 장소 표시
- 더보기 메뉴: 수정하기, 삭제하기 옵션
- IntersectionObserver 기반 무한스크롤
- 공연 없음 상태 및 등록 버튼

### 개선 사항
- ProfileTab: URL 기반 상태 관리로 전환
- PerformanceRegisterButton: 컴포넌트로 추출 (재사용성 향상)
- ProfileInfo: 직접 데이터 페칭으로 props 제거

## 리뷰 포인트

- 무한스크롤이 정상 작동하는지 확인
- 공연 삭제 후 목록이 즉시 업데이트되는지 검증
- 더보기 메뉴의 접근성(ARIA 속성)이 적절한지 검토
- 이미지 최적화 경고가 해결되었는지 확인

## 추가 정보

공연 수정 기능은 공연 수정 페이지 구현 후 연결할 예정입니다.