### PR TITLE
feat: 프로필 페이지 회원 정보 UI 레이아웃 수정

### DIFF
--- a/src/app/profile/_components/profile-info.tsx
+++ b/src/app/profile/_components/profile-info.tsx
@@ -41,8 +41,8 @@ export function ProfileInfo() {
         >
           수정하기
         </Button>
+        <DisplayInput label="닉네임" value={name} />
         <DisplayInput label="이메일" value={email} />
-        <DisplayInput label="이름" value={name} />
       </div>
 
       {/* 이탈 버튼 */}

--- a/src/app/profile/_components/profile-tab.tsx
+++ b/src/app/profile/_components/profile-tab.tsx
@@ -31,43 +31,44 @@ function BaseProfileTab() {
 
   const handleTabChange = (value: string) => {
     const params = new URLSearchParams(searchParams);
-    params.set('tab', value); // tab만 덮어쓰기
+    params.set('tab', value);
     router.replace(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
   return (
     <div className="flex w-full flex-1 flex-col pt-21.25">
-
-      {/* 타이틀: TabsList 밖으로 분리 → 탭 트리거 y=0 기준점 확보 */}
-      <h1 className="mb-25 pl-5 typo-title-sb-2 text-black">마이페이지</h1>
-
       <Tabs
         value={activeTab}
         onValueChange={handleTabChange}
-        className="flex min-h-125 flex-1 flex-row gap-11"
+        className="flex min-h-125 flex-1"
       >
-        {/* 좌: 탭 트리거 — y=0 기준 */}
-        <TabsList className="mb-0 h-full w-55 flex-col bg-transparent p-0">
-          <div className="flex w-full flex-col gap-5 px-5">
-            <ProfileTabTrigger filter="my-info" content="내 정보" />
-            <ProfileTabTrigger filter="my-performances" content="내가 등록한 공연" />
+        <div className="flex w-full flex-row gap-11">
+          <div className="flex w-55 flex-col">
+            <h1 className="mb-25 pl-5 typo-title-sb-2 text-black">마이페이지</h1>
+
+            <TabsList className="h-auto w-full flex-col bg-transparent p-0">
+              <div className="flex w-full flex-col gap-5 px-5">
+                <ProfileTabTrigger filter="my-info" content="내 정보" />
+                <ProfileTabTrigger filter="my-performances" content="내가 등록한 공연" />
+              </div>
+            </TabsList>
           </div>
-        </TabsList>
 
-        <div className="relative flex flex-1 flex-col">
-          <TabsContent
-            value="my-info"
-            className="mt-0 flex flex-1 outline-none"
-          >
-            <ProfileInfo />
-          </TabsContent>
+          <div className="flex flex-1 flex-col">
+            <TabsContent
+              value="my-info"
+              className="mt-0 flex flex-1 outline-none"
+            >
+              <ProfileInfo />
+            </TabsContent>
 
-          <TabsContent
-            value="my-performances"
-            className="mt-0 flex flex-1 outline-none"
-          >
-            <ProfilePerformances />
-          </TabsContent>
+            <TabsContent
+              value="my-performances"
+              className="relative mt-40 flex flex-1 outline-none"
+            >
+              <ProfilePerformances />
+            </TabsContent>
+          </div>
         </div>
       </Tabs>
     </div>
@@ -79,8 +80,8 @@ function ProfileTabTrigger({ filter, content }: ProfileTabTriggerProps) {
     <TabsTrigger
       value={filter}
       className={cn(`
-        h-12.5 w-full items-center justify-center rounded-2xl bg-transparent
-        px-4 py-2 typo-body-m-3 text-black shadow-elevate-1
+        h-12.5 w-full cursor-pointer items-center justify-center rounded-2xl
+        bg-transparent px-4 py-2 typo-body-m-3 text-black shadow-elevate-1
         data-[state=active]:bg-orange-400 data-[state=active]:text-white
       `)}
     >


### PR DESCRIPTION
## 관련 이슈
Closes #176

## 변경사항

회원 정보 표시 영역의 레이아웃을 디자인 시안과 일치하도록 수정했습니다.

### 주요 수정
- DisplayInput 순서: 닉네임 → 이메일 (이전: 이메일 → 이름)
- 라벨 텍스트: "이름" → "닉네임"
- ProfileTabTrigger: cursor-pointer 스타일 추가
- Tabs 레이아웃: 좌우 영역 디자인 시안과 일치하게 UI 레이아웃 수정

## 리뷰 포인트

- 회원 정보 순서가 디자인 시안과 일치하는지 확인
- 라벨 텍스트가 정확하게 변경되었는지 검토
- 탭 영역의 레이아웃이 의도대로 표시되는지 검증