### PR TITLE
fix: Dialog z-index 계층 구조 개선 및 2중 모달 대응

### DIFF
--- a/src/components/common/dialog/dialog.tsx
+++ b/src/components/common/dialog/dialog.tsx
@@ -53,28 +53,30 @@ function DialogContent({
   className,
   children,
   overlayClassName,
+  nested = false,
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
   overlayClassName?: string;
+  nested?: boolean;
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay className={overlayClassName} />
+      <DialogOverlay className={cn(nested && 'z-modal-nested-backdrop', overlayClassName)} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
           `
-            fixed top-[50%] left-[50%] z-modal grid w-full
-            max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4
-            rounded-lg border bg-background p-6 shadow-lg duration-200
-            outline-none
+            fixed top-[50%] left-[50%] grid w-full max-w-[calc(100%-2rem)]
+            translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border
+            bg-background p-6 shadow-lg duration-200 outline-none
             data-[state=closed]:animate-out data-[state=closed]:fade-out-0
             data-[state=closed]:zoom-out-95
             data-[state=open]:animate-in data-[state=open]:fade-in-0
             data-[state=open]:zoom-in-95
           `,
+          nested ? 'z-modal-nested' : 'z-modal',
           className,
         )}
         {...props}

--- a/src/components/common/dialog/dialog.tsx
+++ b/src/components/common/dialog/dialog.tsx
@@ -38,7 +38,7 @@ function DialogOverlay({
       data-slot="dialog-overlay"
       className={cn(
         `
-          fixed inset-0 z-modal bg-black/50
+          fixed inset-0 z-modal-backdrop bg-black/50
           data-[state=closed]:animate-out data-[state=closed]:fade-out-0
           data-[state=open]:animate-in data-[state=open]:fade-in-0
         `,
@@ -52,21 +52,24 @@ function DialogOverlay({
 function DialogContent({
   className,
   children,
+  overlayClassName,
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
+  overlayClassName?: string;
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
           `
-            fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)]
-            translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border
-            bg-background p-6 shadow-lg duration-200 outline-none
+            fixed top-[50%] left-[50%] z-modal grid w-full
+            max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4
+            rounded-lg border bg-background p-6 shadow-lg duration-200
+            outline-none
             data-[state=closed]:animate-out data-[state=closed]:fade-out-0
             data-[state=closed]:zoom-out-95
             data-[state=open]:animate-in data-[state=open]:fade-in-0

--- a/src/components/performance/search-modal.tsx
+++ b/src/components/performance/search-modal.tsx
@@ -88,6 +88,7 @@ export function SearchModal({ onSelect, trigger }: LocationSearchModalProps) {
           pt-12
         `}
         showCloseButton={false}
+        overlayClassName="z-modal-nested-backdrop"
       >
 
         <button

--- a/src/components/performance/search-modal.tsx
+++ b/src/components/performance/search-modal.tsx
@@ -88,7 +88,7 @@ export function SearchModal({ onSelect, trigger }: LocationSearchModalProps) {
           pt-12
         `}
         showCloseButton={false}
-        overlayClassName="z-modal-nested-backdrop"
+        nested
       >
 
         <button


### PR DESCRIPTION
## 관련 이슈
Closes #184

## 변경사항

Dialog 컴포넌트의 z-index를 재조정하고 2중 모달을 지원하도록 개선했습니다.

### 주요 수정
- DialogOverlay: z-modal → z-modal-backdrop (배경층)
- DialogContent: z-50 → z-modal (콘텐츠층)
- overlayClassName prop 추가로 동적 오버레이 스타일 제어 가능
- SearchModal: overlayClassName="z-modal-nested-backdrop" 추가

## 리뷰 포인트

- Dialog Content가 Overlay 위에 올바르게 표시되는지 확인
- 2중 모달 렌더링 시 z-index가 정상 작동하는지 검증
- 기존 모달들과 z-index 충돌이 없는지 확인