### PR TITLE
feat: [프로필] 회원 정보 수정 기능 구현

### DIFF
--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -1,2 +1,2 @@
-export { getUser, logoutUser } from './user.api';
-export type { LogoutResponseDto, UserResponseDto } from './user.schema';
+export { getUser, logoutUser, patchUser } from './user.api';
+export type { LogoutResponseDto, UpdateMemberNameRequestDto, UserResponseDto } from './user.schema';

--- a/src/apis/user/user.api.ts
+++ b/src/apis/user/user.api.ts
@@ -1,10 +1,15 @@
 import type { FetchConfig } from '../api.types';
+import type { UpdateMemberNameRequestDto } from './user.schema';
 import { api } from '../api.instance';
 import { parseResponse } from '../api.parse';
 import { UserResponseDtoSchema } from './user.schema';
 
 export function getUser(config?: FetchConfig) {
   return api.get('/api/members/me', config).then(parseResponse(UserResponseDtoSchema));
+}
+
+export function patchUser(data: UpdateMemberNameRequestDto, config?: FetchConfig) {
+  return api.patch('/api/members/me', data, config).then(parseResponse(UserResponseDtoSchema));
 }
 
 export function logoutUser(config?: FetchConfig) {

--- a/src/apis/user/user.schema.ts
+++ b/src/apis/user/user.schema.ts
@@ -8,6 +8,12 @@ export const UserResponseDtoSchema = z.object({
 
 export type UserResponseDto = z.infer<typeof UserResponseDtoSchema>;
 
+export const UpdateMemberNameRequestDtoSchema = z.object({
+  name: z.string().min(2).max(15),
+});
+
+export type UpdateMemberNameRequestDto = z.infer<typeof UpdateMemberNameRequestDtoSchema>;
+
 export const LogoutResponseDtoSchema = z.object({
   code: z.string(),
   message: z.string(),

--- a/src/apis/user/user.schema.ts
+++ b/src/apis/user/user.schema.ts
@@ -9,7 +9,10 @@ export const UserResponseDtoSchema = z.object({
 export type UserResponseDto = z.infer<typeof UserResponseDtoSchema>;
 
 export const UpdateMemberNameRequestDtoSchema = z.object({
-  name: z.string().min(2).max(15),
+  name: z
+    .string()
+    .min(2, { message: '최소2자~최대 15자까지 입력 가능합니다.' })
+    .max(15, { message: '최소2자~최대 15자까지 입력 가능합니다.' }),
 });
 
 export type UpdateMemberNameRequestDto = z.infer<typeof UpdateMemberNameRequestDtoSchema>;

--- a/src/app/profile/_components/profile-edit-modal.tsx
+++ b/src/app/profile/_components/profile-edit-modal.tsx
@@ -45,7 +45,13 @@ export function ProfileEditModal({ open, onOpenChange, currentName }: ProfileEdi
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!isPending)
+          onOpenChange(nextOpen);
+      }}
+    >
       <DialogContent
         showCloseButton={false}
         className="w-143.75 gap-0 px-28.5 py-16.25"
@@ -70,6 +76,7 @@ export function ProfileEditModal({ open, onOpenChange, currentName }: ProfileEdi
               theme="gray"
               appearance="filled"
               size="md"
+              disabled={isPending}
               onClick={() => onOpenChange(false)}
             >
               취소

--- a/src/app/profile/_components/profile-edit-modal.tsx
+++ b/src/app/profile/_components/profile-edit-modal.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import type { UpdateMemberNameRequestDto } from '@/apis/user';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { UpdateMemberNameRequestDtoSchema } from '@/apis/user/user.schema';
+import { Button } from '@/components/common/button';
+import { Dialog, DialogContent, DialogTitle } from '@/components/common/dialog';
+import { FormInput } from '@/components/common/input';
+import { useUpdateMemberName } from '@/hooks/member/use-update-member-name';
+
+interface ProfileEditModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentName: string;
+}
+
+export function ProfileEditModal({ open, onOpenChange, currentName }: ProfileEditModalProps) {
+  const { mutate: updateName, isPending } = useUpdateMemberName();
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { errors },
+  } = useForm<UpdateMemberNameRequestDto>({
+    resolver: zodResolver(UpdateMemberNameRequestDtoSchema),
+    defaultValues: { name: currentName },
+    mode: 'onSubmit',
+    reValidateMode: 'onSubmit',
+  });
+
+  // 모달이 열릴 때마다 현재 닉네임으로 초기화
+  useEffect(() => {
+    if (open)
+      reset({ name: currentName });
+  }, [open, currentName, reset]);
+
+  const nameValue = watch('name') ?? '';
+
+  const onSubmit = (data: UpdateMemberNameRequestDto) => {
+    updateName(data, { onSuccess: () => onOpenChange(false) });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="w-143.75 gap-0 px-28.5 py-16.25"
+      >
+        <DialogTitle className="typo-body-sb-1 text-black">닉네임 변경</DialogTitle>
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="mt-12.5 flex flex-col gap-16.75"
+        >
+          <FormInput
+            label="닉네임"
+            placeholder="닉네임을 입력해 주세요"
+            showCount
+            maxLength={15}
+            currentCount={nameValue.length}
+            error={errors.name?.message}
+            {...register('name')}
+          />
+          <div className="flex justify-center gap-2.5">
+            <Button
+              type="button"
+              theme="gray"
+              appearance="filled"
+              size="md"
+              onClick={() => onOpenChange(false)}
+            >
+              취소
+            </Button>
+            <Button
+              type="submit"
+              theme="orange"
+              appearance="filled"
+              size="md"
+              disabled={isPending}
+            >
+              확인
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/profile/_components/profile-info.tsx
+++ b/src/app/profile/_components/profile-info.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 import { Button } from '@/components/common/button';
 import { AvatarCircleIcon } from '@/components/common/icon';
 import { userQueryOptions } from '@/queries/user/user.query';
 import { cn } from '@/utils';
+import { ProfileEditModal } from './profile-edit-modal';
 
 interface DisplayInputProps {
   label: string;
@@ -13,6 +15,7 @@ interface DisplayInputProps {
 
 export function ProfileInfo() {
   const { data: { email, name } } = useSuspenseQuery(userQueryOptions);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
     <section className="flex w-full flex-col items-center gap-16.75">
@@ -38,6 +41,7 @@ export function ProfileInfo() {
           appearance="outline"
           size="sm"
           className="absolute right-0 mr-91.5"
+          onClick={() => setIsModalOpen(true)}
         >
           수정하기
         </Button>
@@ -52,6 +56,11 @@ export function ProfileInfo() {
       </div>
 
       {/* 프로필 수정 모달 */}
+      <ProfileEditModal
+        open={isModalOpen}
+        onOpenChange={setIsModalOpen}
+        currentName={name}
+      />
     </section>
   );
 }

--- a/src/hooks/member/index.ts
+++ b/src/hooks/member/index.ts
@@ -1,0 +1,1 @@
+export { useUpdateMemberName } from './use-update-member-name';

--- a/src/hooks/member/use-update-member-name.ts
+++ b/src/hooks/member/use-update-member-name.ts
@@ -1,0 +1,18 @@
+import type { UpdateMemberNameRequestDto } from '@/apis/user';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { patchUser } from '@/apis/user';
+import { userQueryOptions } from '@/queries/user/user.query';
+
+export function useUpdateMemberName() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: UpdateMemberNameRequestDto) => patchUser(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: userQueryOptions.queryKey });
+    },
+    onError: () => {
+      // TODO: 서버 에러에 대응하는 toast 알림 추가 예정
+    },
+  });
+}


### PR DESCRIPTION
## 관련 이슈
Closes #177

## 변경사항

회원 닉네임 수정 모달을 구현하고 API를 연결했습니다.

### API 계층
- patchUser: PATCH /api/members/me 회원 정보 수정 API
- UpdateMemberNameRequestDtoSchema: 닉네임 검증 (2-15자)
- useUpdateMemberName: mutation hook (성공 시 회원 정보 쿼리 무효화)

### UI 컴포넌트
- ProfileEditModal: 닉네임 입력, 문자 개수 표시, 유효성 검증
- React Hook Form + Zod resolver로 폼 관리
- 모달 열 때마다 현재 닉네임으로 동기화

## 리뷰 포인트

- 닉네임 검증이 2-15자 규칙을 정확히 적용하는지 확인
- mutation 성공 후 회원 정보가 즉시 업데이트되는지 검증
- 문자 개수 표시가 정상 작동하는지 확인

## 추가 정보

API 실패 시 Toast 알림과 동일 닉네임 검증은 추후 작업 예정입니다.