### PR TITLE
feat: [공연 상세] Kakao Map 연동

### DIFF
--- a/src/app/performance-detail/[performanceId]/_components/performance-info.tsx
+++ b/src/app/performance-detail/[performanceId]/_components/performance-info.tsx
@@ -16,7 +16,7 @@ interface PerformanceInfoProps {
 
 export function PerformanceInfo({ performanceId }: PerformanceInfoProps) {
   const { data: performanceDetail } = useSuspenseQuery(performanceDetailQueryOptions(performanceId));
-  const { title, performanceDate, locationName, images, summary, startTime, endTime, performers, description } = performanceDetail;
+  const { title, performanceDate, locationName, images, summary, startTime, endTime, performers, description, latitude, longitude } = performanceDetail;
   const router = useRouter();
 
   return (
@@ -37,7 +37,7 @@ export function PerformanceInfo({ performanceId }: PerformanceInfoProps) {
         performers={performers[0] ?? { name: '', email: '', phoneNumber: '' }}
         description={description}
       />
-      <PerformanceLocation />
+      <PerformanceLocation coordinate={{ lat: latitude, lng: longitude }} />
       <div className="flex justify-center pt-17.5 pb-20.75">
         <Button
           onClick={() => {

--- a/src/app/performance-detail/[performanceId]/_components/performance-location.tsx
+++ b/src/app/performance-detail/[performanceId]/_components/performance-location.tsx
@@ -7,13 +7,15 @@ import { useKakaoLoader } from '@/hooks/kakao-map/use-kakao-loader';
 import { useKakaoMap } from '@/hooks/kakao-map/use-kakao-map';
 import { useKakaoMarkers } from '@/hooks/kakao-map/use-kakao-markers';
 
+const DEFAULT_MAP_LEVEL = 3;
+
 interface PerformanceLocationProps {
   coordinate: Coordinate;
 }
 
 export function PerformanceLocation({ coordinate }: PerformanceLocationProps) {
   const { isLoaded, error } = useKakaoLoader();
-  const { mapContainerRef, map } = useKakaoMap({ isLoaded, center: coordinate, level: 3 });
+  const { mapContainerRef, map } = useKakaoMap({ isLoaded, center: coordinate, level: DEFAULT_MAP_LEVEL });
 
   const markers = useMemo(
     () => [{ id: 'performance-location', position: coordinate }],
@@ -28,7 +30,7 @@ export function PerformanceLocation({ coordinate }: PerformanceLocationProps) {
     }
 
     map.setCenter(new window.kakao.maps.LatLng(coordinate.lat, coordinate.lng));
-    map.setLevel(3);
+    map.setLevel(DEFAULT_MAP_LEVEL);
   }, [map, coordinate]);
 
   return (
@@ -39,11 +41,23 @@ export function PerformanceLocation({ coordinate }: PerformanceLocationProps) {
           ? (
               <div
                 className={`
-                  flex h-full items-center justify-center text-gray-400
+                  flex h-full flex-col items-center justify-center gap-3
+                  text-gray-400
                 `}
                 role="alert"
               >
-                지도를 불러오지 못했습니다.
+                <p>지도를 불러오지 못했습니다.</p>
+                <button
+                  type="button"
+                  onClick={() => window.location.reload()}
+                  className={`
+                    rounded-full bg-gray-100 px-4 py-1.5 typo-caption-r-1
+                    text-gray-600
+                    hover:bg-gray-200
+                  `}
+                >
+                  다시 시도
+                </button>
               </div>
             )
           : (

--- a/src/app/performance-detail/[performanceId]/_components/performance-location.tsx
+++ b/src/app/performance-detail/[performanceId]/_components/performance-location.tsx
@@ -1,21 +1,81 @@
-import { MapPin } from 'lucide-react';
+'use client';
 
-export function PerformanceLocation() {
+import type { Coordinate } from '@/types/kakao/kakao-map';
+import { LocateFixed } from 'lucide-react';
+import { useCallback, useMemo } from 'react';
+import { useKakaoLoader } from '@/hooks/kakao-map/use-kakao-loader';
+import { useKakaoMap } from '@/hooks/kakao-map/use-kakao-map';
+import { useKakaoMarkers } from '@/hooks/kakao-map/use-kakao-markers';
+
+interface PerformanceLocationProps {
+  coordinate: Coordinate;
+}
+
+export function PerformanceLocation({ coordinate }: PerformanceLocationProps) {
+  const { isLoaded, error } = useKakaoLoader();
+  const { mapContainerRef, map } = useKakaoMap({ isLoaded, center: coordinate, level: 3 });
+
+  const markers = useMemo(
+    () => [{ id: 'performance-location', position: coordinate }],
+    [coordinate],
+  );
+
+  useKakaoMarkers(map, markers);
+
+  const handleReset = useCallback(() => {
+    if (!map) {
+      return;
+    }
+
+    map.setCenter(new window.kakao.maps.LatLng(coordinate.lat, coordinate.lng));
+    map.setLevel(3);
+  }, [map, coordinate]);
+
   return (
     <div className="border-b-2 border-gray-200 pt-5 pb-12.5">
       <h3 className="py-2.5 typo-title-b-5 text-black">위치 안내</h3>
-      <div className={`
-        mt-3.75 flex h-[400px] w-full flex-col items-center justify-center gap-4
-        rounded-lg bg-gray-50 text-gray-400
-      `}
-      >
-        <div className="rounded-full bg-gray-100 p-4">
-          <MapPin className="h-8 w-8 text-gray-500" />
-        </div>
-        <div className="text-center">
-          <p className="typo-title-sb-4 text-gray-600">지도 서비스 준비 중</p>
-          <p className="mt-1 typo-body-m-3">조금만 기다려주세요!</p>
-        </div>
+      <div className="relative mt-3.75 h-100 w-full overflow-hidden rounded-lg">
+        {error
+          ? (
+              <div
+                className={`
+                  flex h-full items-center justify-center text-gray-400
+                `}
+                role="alert"
+              >
+                지도를 불러오지 못했습니다.
+              </div>
+            )
+          : (
+              <>
+                <div ref={mapContainerRef} className="h-full w-full" />
+                {!isLoaded && (
+                  <div
+                    className={`
+                      absolute inset-0 flex items-center justify-center
+                    `}
+                    role="status"
+                  >
+                    로딩중...
+                  </div>
+                )}
+                {isLoaded && map && (
+                  <button
+                    type="button"
+                    onClick={handleReset}
+                    className={`
+                      absolute right-3 bottom-3 z-10 flex cursor-pointer
+                      items-center gap-1.5 rounded-full bg-white px-3 py-1.5
+                      typo-caption-r-1 text-gray-700 shadow-md
+                      hover:bg-gray-50
+                    `}
+                  >
+                    <LocateFixed className="h-3.5 w-3.5" />
+                    위치 초기화
+                  </button>
+                )}
+              </>
+            )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 관련 이슈
Closes #179

## 변경사항

공연 위치를 Kakao Map으로 표시하는 기능을 구현했습니다.

### 주요 구현
- useKakaoLoader: Kakao Maps API 비동기 로드
- useKakaoMap: 지도 인스턴스 생성 및 중심 설정 (레벨 3)
- useKakaoMarkers: 마커 렌더링
- PerformanceLocation: 좌표 기반 지도 렌더링
- 위치 초기화 버튼: 원래 중심과 레벨로 복구
- 로딩/에러 상태 UI

## 리뷰 포인트

- 지도가 정상 렌더링되는지 확인
- 마커가 올바른 좌표에 표시되는지 검증
- 위치 초기화 버튼이 정상 작동하는지 확인
- 로딩 상태 UI가 적절하게 표시되는지 검토