### PR TITLE
chore: Tailwind CSS 반응형 Breakpoint 설정

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -261,7 +261,7 @@ body {
   padding-right: 1.25rem; /* 20px */
 
   /* 태블릿 이상에서 패딩 증가 */
-  @media (min-width: 768px) {
+  @media (min-width: var(--breakpoint-md)) {
     padding-left: 2.5rem; /* 40px */
     padding-right: 2.5rem; /* 40px */
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,14 @@
 @import 'tw-animate-css';
 @import './typography.css';
 
+/* 디자인 시스템 브레이크포인트 */
+@theme {
+  --breakpoint-sm: 36rem; /* 576px */
+  --breakpoint-md: 48rem; /* 768px */
+  --breakpoint-lg: 64rem; /* 1024px */
+  --breakpoint-xl: 75rem; /* 1200px */
+}
+
 @custom-variant dark (&:is(.dark *));
 
 :root {


### PR DESCRIPTION
## 관련 이슈
Closes #192

## 변경사항

Tailwind CSS v4+ @theme을 사용하여 커스텀 브레이크포인트를 정의했습니다.

### Breakpoint 설정
- sm: 36rem (576px)
- md: 48rem (768px)
- lg: 64rem (1024px)
- xl: 75rem (1200px)
- globals.css @theme 섹션에 정의

## 리뷰 포인트

- 브레이크포인트가 globals.css에 정상 정의되었는지 확인
- Tailwind CLI에서 인식되는지 검증
- 기존 반응형 클래스들과 호환되는지 확인