### PR TITLE
feat: [법적 약관] 서비스 약관 및 개인정보 처리방침 페이지 구현

### DIFF
--- a/src/app/(legal)/_components/legal-confirm-button/index.ts
+++ b/src/app/(legal)/_components/legal-confirm-button/index.ts
@@ -1,0 +1,1 @@
+export { LegalConfirmButton } from './legal-confirm-button';

--- a/src/app/(legal)/_components/legal-confirm-button/legal-confirm-button.tsx
+++ b/src/app/(legal)/_components/legal-confirm-button/legal-confirm-button.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/common/button';
+
+export function LegalConfirmButton() {
+  const router = useRouter();
+  return (
+    <Button appearance="filled" theme="gray" size="md" onClick={() => router.back()}>
+      확인
+    </Button>
+  );
+}

--- a/src/app/(legal)/_components/legal-layout/index.ts
+++ b/src/app/(legal)/_components/legal-layout/index.ts
@@ -1,0 +1,1 @@
+export { LegalLayout } from './legal-layout';

--- a/src/app/(legal)/_components/legal-layout/legal-layout.tsx
+++ b/src/app/(legal)/_components/legal-layout/legal-layout.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+import { HomeFooter } from '@/app/_components/home-footer';
+import { Header } from '@/components/common/header';
+import { MainLayout } from '@/components/layout';
+import { cn } from '@/utils';
+import { LegalConfirmButton } from '../legal-confirm-button';
+
+interface LegalLayoutProps {
+  title: string;
+  children: ReactNode;
+}
+
+export function LegalLayout({ title, children }: LegalLayoutProps) {
+  return (
+    <div className="min-h-screen bg-white">
+      <MainLayout className="pt-6.25">
+        <Header />
+      </MainLayout>
+
+      <main
+        className={cn(
+          'container-1920 py-17.5',
+          'md:pt-21.25 md:pb-39.75',
+        )}
+      >
+        <section className="flex flex-col items-center">
+          <h1 className="text-center typo-title-b-3 text-black">{title}</h1>
+
+          <div
+            className={cn(
+              'mt-12.5',
+              `
+                md:mt-20.5 md:h-211.5 md:w-205.5 md:overflow-y-auto
+                md:rounded-lg md:bg-gray-50
+              `,
+              'md:px-11.25 md:py-7.5',
+            )}
+          >
+            {children}
+          </div>
+
+          <div
+            className={cn(
+              'mt-15 hidden',
+              'md:flex md:justify-center',
+            )}
+          >
+            <LegalConfirmButton />
+          </div>
+        </section>
+      </main>
+
+      <div className={cn('hidden', 'md:block')}>
+        <HomeFooter />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(legal)/_components/legal-layout/legal-layout.tsx
+++ b/src/app/(legal)/_components/legal-layout/legal-layout.tsx
@@ -24,14 +24,20 @@ export function LegalLayout({ title, children }: LegalLayoutProps) {
         )}
       >
         <section className="flex flex-col items-center">
-          <h1 className="text-center typo-title-b-3 text-black">{title}</h1>
+          <h1 className={cn(
+            `text-center typo-title-b-5 text-black`,
+            `md:typo-title-b-3`,
+          )}
+          >
+            {title}
+          </h1>
 
           <div
             className={cn(
               'mt-12.5',
               `
-                md:mt-20.5 md:h-211.5 md:w-205.5 md:overflow-y-auto
-                md:rounded-lg md:bg-gray-50
+                md:mt-20.5 md:h-211.5 md:w-full md:max-w-205.5
+                md:overflow-y-auto md:rounded-lg md:bg-gray-50
               `,
               'md:px-11.25 md:py-7.5',
             )}

--- a/src/app/(legal)/privacy/_components/index.ts
+++ b/src/app/(legal)/privacy/_components/index.ts
@@ -1,0 +1,1 @@
+export { PrivacyContent } from './privacy-content';

--- a/src/app/(legal)/privacy/_components/privacy-content.tsx
+++ b/src/app/(legal)/privacy/_components/privacy-content.tsx
@@ -38,7 +38,7 @@ export function PrivacyContent() {
       </section>
 
       <section className="flex flex-col gap-2">
-        <h2 className="typo-body-sb-3 text-black">제 5조 ( 회원 가입을 위한 정보 )</h2>
+        <h2 className="typo-body-sb-3 text-black">제 4조 ( 회원 가입을 위한 정보 )</h2>
         <p className="typo-caption-r-2 leading-relaxed">
           회사는 이용자의 회사 서비스에 대한 회원가입을 위하여 다음과 같은 정보를 수집합니다.
         </p>
@@ -53,7 +53,7 @@ export function PrivacyContent() {
       </section>
 
       <section className="flex flex-col gap-2">
-        <h2 className="typo-body-sb-3 text-black">제 6조 ( 결제 서비스를 위한 정보 )</h2>
+        <h2 className="typo-body-sb-3 text-black">제 5조 ( 결제 서비스를 위한 정보 )</h2>
         <p className="typo-caption-r-2 leading-relaxed">
           회사는 이용자에게 회사의 결제 서비스 제공을 위하여 다음과 같은 정보를 수집합니다.
         </p>
@@ -63,7 +63,7 @@ export function PrivacyContent() {
       </section>
 
       <section className="flex flex-col gap-2">
-        <h2 className="typo-body-sb-3 text-black">제 7조 ( 현금 영수증 발행을 위한 정보 )</h2>
+        <h2 className="typo-body-sb-3 text-black">제 6조 ( 현금 영수증 발행을 위한 정보 )</h2>
         <p className="typo-caption-r-2 leading-relaxed">
           회사는 이용자의 현금 영수증을 발행하기 위하여 다음과 같은 정보를 수집합니다.
         </p>
@@ -73,7 +73,7 @@ export function PrivacyContent() {
       </section>
 
       <section className="flex flex-col gap-2">
-        <h2 className="typo-body-sb-3 text-black">제 8조 ( 회사 서비스 제공을 위한 정보 )</h2>
+        <h2 className="typo-body-sb-3 text-black">제 7조 ( 회사 서비스 제공을 위한 정보 )</h2>
         <p className="typo-caption-r-2 leading-relaxed">
           회사는 이용자에게 회사의 서비스를 제공하기 위해서 다음과 같은 정보를 수집합니다.
         </p>
@@ -88,7 +88,7 @@ export function PrivacyContent() {
       </section>
 
       <section className="flex flex-col gap-2">
-        <h2 className="typo-body-sb-3 text-black">제 9조 ( 서비스 이용 및 부정 이용 확인을 위한 정보 )</h2>
+        <h2 className="typo-body-sb-3 text-black">제 8조 ( 서비스 이용 및 부정 이용 확인을 위한 정보 )</h2>
         <p className="typo-caption-r-2 leading-relaxed">
           회사는 이용자의 서비스 이용 및 부정이용의 확인 및 분석을 위하여 다음과 같은 정보를 수집합니다.
         </p>
@@ -104,7 +104,7 @@ export function PrivacyContent() {
       </section>
 
       <section className="flex flex-col gap-2">
-        <h2 className="typo-body-sb-3 text-black">제 10조 ( 개인정보 수집 방법 )</h2>
+        <h2 className="typo-body-sb-3 text-black">제 9조 ( 개인정보 수집 방법 )</h2>
         <p className="typo-caption-r-2 leading-relaxed">
           회사는 다음과 같은 방법으로 이용자의 개인정보를 수집합니다.
         </p>
@@ -116,7 +116,7 @@ export function PrivacyContent() {
       </section>
 
       <section className="flex flex-col gap-2">
-        <h2 className="typo-body-sb-3 text-black">제 11조 ( 개인정보의 이용 )</h2>
+        <h2 className="typo-body-sb-3 text-black">제 10조 ( 개인정보의 이용 )</h2>
         <p className="typo-caption-r-2 leading-relaxed">
           회사는 개인정보를 다음 각 호의 경우에 이용합니다.
         </p>
@@ -133,7 +133,7 @@ export function PrivacyContent() {
       </section>
 
       <section className="flex flex-col gap-2">
-        <h2 className="typo-body-sb-3 text-black">제 12조 ( 개인정보 처리 위탁 )</h2>
+        <h2 className="typo-body-sb-3 text-black">제 11조 ( 개인정보 처리 위탁 )</h2>
         <p className="typo-caption-r-2 leading-relaxed">
           회사는 원활한 서비스 제공과 효과적인 업무를 처리하기 위하여 다음 각 호와 같이 개인정보를 처리 위탁하고 있습니다.
         </p>
@@ -145,7 +145,7 @@ export function PrivacyContent() {
       </section>
 
       <section className="flex flex-col gap-2">
-        <h2 className="typo-body-sb-3 text-black">제 13조 ( 개인정보의 보유 및 이용기간 )</h2>
+        <h2 className="typo-body-sb-3 text-black">제 12조 ( 개인정보의 보유 및 이용기간 )</h2>
         <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
           <li>회사는 이용자의 개인정보에 대해 개인정보의 수집, 이용 목적 달성을 위한 기간 동안 개인정보를 보유 및 이용합니다.</li>
           <li>전항에도 불구하고 회사는 내부 방침에 의해 서비스 부정이용기록은 부정 가입 및 이용 방지를 위하여 회원 탈퇴 시점으로부터 최대 1년간 보관합니다.</li>
@@ -153,7 +153,7 @@ export function PrivacyContent() {
       </section>
 
       <section className="flex flex-col gap-2">
-        <h2 className="typo-body-sb-3 text-black">제 14조 ( 법령에 따른 개인정보의 보유 및 이용기간 )</h2>
+        <h2 className="typo-body-sb-3 text-black">제 13조 ( 법령에 따른 개인정보의 보유 및 이용기간 )</h2>
         <p className="typo-caption-r-2 leading-relaxed">
           회사는 관계법령에 따라 다음과 같이 개인정보를 보유 및 이용합니다.
         </p>

--- a/src/app/(legal)/privacy/_components/privacy-content.tsx
+++ b/src/app/(legal)/privacy/_components/privacy-content.tsx
@@ -1,0 +1,192 @@
+export function PrivacyContent() {
+  return (
+    <div className="flex flex-col gap-8 text-gray-700">
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 1조 ( 목적 )</h2>
+        <p className="typo-caption-r-2 leading-relaxed">
+          고스락(이하 "회사"라고 함)는 회사가 제공하고자 하는 서비스 (이하 "회사 서비스")를 이용하는 개인
+          ( 이하 "이용자" 또는 "개인")의 정보( 이하 "개인정보")를 보호하기 위해, 개인정보보호법,
+          정보통신망 이용촉진 및 정보보호 등에 관한 법률(이하 '정보통신망법') 등 관련 법령을 준수하고,
+          서비스 이용자의 개인정보 보호 관련한 고충을 신속하고 원할하게 처리할 수 있도록 하기 위하여
+          다음과 같이 개인정보처리 방침 ( 이하 "본 방침")을 수립합니다.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 2조 ( 개인정보 처리의 원칙 )</h2>
+        <p className="typo-caption-r-2 leading-relaxed">
+          개인정보 관련 법령 및 본 방침에 따라 회사는 이용자의 개인정보를 수집할 수 있으며
+          수집된 개인정보는 개인의 동의가 있는 경우에 한해 제 3자에게 제공될 수 있습니다.
+          단, 법령의 규정 등에 의해 적법하게 강제되는 경우 회사는 수집한 이용자의 개인정보를
+          사전에 개인의 동의 없이 제 3자에게 제공할 수도 있습니다.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 3조 ( 본 방침의 변경 )</h2>
+        <ol className="flex list-decimal flex-col gap-2 pl-5 typo-caption-r-2">
+          <li>본 방침은 개인정보 관련 법령, 지침, 고시 또는 정부나 회사 서비스의 정책이나 내용의 변경에 따라 개정될 수 있습니다.</li>
+          <li>
+            회사는 제 1항에 따라 본 방침을 개정하는 경우 다음 각 호 하나 이상의 방법으로 공지합니다.
+            <ol className="mt-1 flex list-[lower-alpha] flex-col gap-1 pl-5">
+              <li>회사가 운영하는 인터넷 홈페이지의 첫 화면의 공지사항란 또는 별도의 창을 통하여 공지하는 방법</li>
+              <li>서면, 모사전송, 전자우편 또는 이와 비슷한 방법으로 이용자에게 공지하는 방법</li>
+            </ol>
+          </li>
+          <li>회사는 제 2항의 공지는 본 방침 개정의 시행일로부터 최소 7일 이전에 공지합니다. 다만, 이용자 권리의 중요한 변경이 있을 경우에는 최소 30일 전에 공지합니다.</li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 5조 ( 회원 가입을 위한 정보 )</h2>
+        <p className="typo-caption-r-2 leading-relaxed">
+          회사는 이용자의 회사 서비스에 대한 회원가입을 위하여 다음과 같은 정보를 수집합니다.
+        </p>
+        <ol className="flex list-decimal flex-col gap-2 pl-5 typo-caption-r-2">
+          <li>
+            필수 수집 정보
+            <ol className="mt-1 flex list-[lower-alpha] flex-col gap-1 pl-5">
+              <li>카카오톡 회원가입의 경우 : 이메일 주소, 이름, 닉네임, 생년월일 및 휴대폰 연락처, 프로필 사진</li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 6조 ( 결제 서비스를 위한 정보 )</h2>
+        <p className="typo-caption-r-2 leading-relaxed">
+          회사는 이용자에게 회사의 결제 서비스 제공을 위하여 다음과 같은 정보를 수집합니다.
+        </p>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>필수 수집 정보 : 카드번호, 유효기간, 생년월일 6자리 및 은행명</li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 7조 ( 현금 영수증 발행을 위한 정보 )</h2>
+        <p className="typo-caption-r-2 leading-relaxed">
+          회사는 이용자의 현금 영수증을 발행하기 위하여 다음과 같은 정보를 수집합니다.
+        </p>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>필수 수집 정보 : 현금영수증 발행 대상자 이름, 현금영수증 발행 대상자 생년월일, 현금영수증 발행 대상자 주소, 휴대폰 번호 및 현금영수증 카드번호</li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 8조 ( 회사 서비스 제공을 위한 정보 )</h2>
+        <p className="typo-caption-r-2 leading-relaxed">
+          회사는 이용자에게 회사의 서비스를 제공하기 위해서 다음과 같은 정보를 수집합니다.
+        </p>
+        <ol className="flex list-decimal flex-col gap-2 pl-5 typo-caption-r-2">
+          <li>
+            필수 수집 정보
+            <ol className="mt-1 flex list-[lower-alpha] flex-col gap-1 pl-5">
+              <li>카카오톡 회원가입한 개인의 경우 : 이메일 주소, 이름, 닉네임, 생년월일 및 휴대폰 연락처, 프로필 사진</li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 9조 ( 서비스 이용 및 부정 이용 확인을 위한 정보 )</h2>
+        <p className="typo-caption-r-2 leading-relaxed">
+          회사는 이용자의 서비스 이용 및 부정이용의 확인 및 분석을 위하여 다음과 같은 정보를 수집합니다.
+        </p>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>필수 수집 정보 : 서비스 이용기록, 쿠키, 접속지 정보 및 기기정보</li>
+        </ol>
+        <p className="typo-caption-r-2 leading-relaxed text-gray-600">
+          * 부정이용 : 회원탈퇴 후 재가입, 상품구매 후 구매취소 등을 반복적으로 행하는 등 회사가 제공하는
+          할인쿠폰, 이벤트 혜택 등의 경제상 이익을 불법적, 편법적으로 수취하는 행위, 이용약관 등에서
+          금지하고 있는 행위, 명의도용 등의 불법, 편법행위 등을 말합니다. 수집되는 정보는 회사 서비스
+          이용에 따른 통계, 분석에 이용될 수 있습니다.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 10조 ( 개인정보 수집 방법 )</h2>
+        <p className="typo-caption-r-2 leading-relaxed">
+          회사는 다음과 같은 방법으로 이용자의 개인정보를 수집합니다.
+        </p>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>이용자가 회사의 홈페이지에 자신의 개인정보를 입력하는 방식</li>
+          <li>어플리케이션 등 회사가 제공하는 홈페이지 외의 서비스를 통해 이용자가 자신의 개인정보를 입력하는 방식</li>
+          <li>이용자가 고객센터(고스락 카카오톡 채널 등) 상담, 게시판에서의 활동 등 회사의 서비스를 이용하는 과정에서 이용자가 입력하는 방식</li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 11조 ( 개인정보의 이용 )</h2>
+        <p className="typo-caption-r-2 leading-relaxed">
+          회사는 개인정보를 다음 각 호의 경우에 이용합니다.
+        </p>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>공지사항 전달 등 회사의 운영에 필요한 경우</li>
+          <li>이용문의에 대한 회신, 불만의 처리 등 이용자에 대한 서비스 개선을 위한 경우</li>
+          <li>회사의 서비스를 제공하기 위한 경우</li>
+          <li>신규 서비스 개발을 위한 경우</li>
+          <li>이벤트 및 행사 안내 등 마케팅을 위한 경우</li>
+          <li>인구 통계학적 분석, 서비스 방문 및 이용기록의 분석을 위한 경우</li>
+          <li>개인정보 및 관심에 기반한 이용자간 관계의 형성을 위한 경우</li>
+          <li>법령 및 회사 약관을 위반하는 회원에 대한 이용 제한 조치, 부정 이용 행위를 포함하여 서비스의 원활한 운영에 지장을 주는 행위에 대한 방지 및 제재를 위한 경우</li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 12조 ( 개인정보 처리 위탁 )</h2>
+        <p className="typo-caption-r-2 leading-relaxed">
+          회사는 원활한 서비스 제공과 효과적인 업무를 처리하기 위하여 다음 각 호와 같이 개인정보를 처리 위탁하고 있습니다.
+        </p>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>토스페이먼츠(주) 에게 결제대행(PG), 현금 영수증 발행을 위하여 5년동안 개인정보 처리를 위탁함</li>
+          <li>Amazon Web Services Inc. 에게 서비스 이용 기록, 수집된 개인정보를 서비스 운영을 위하여 현재 회사가 이용중인 클라우드 서비스 이용 변경시까지(국내 서울 리전) 개인정보처리를 위탁함</li>
+          <li>네이버 클라우드. 카카오톡 알림톡, 문자발송 등을 위해 개인정보 처리를 위탁함</li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 13조 ( 개인정보의 보유 및 이용기간 )</h2>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>회사는 이용자의 개인정보에 대해 개인정보의 수집, 이용 목적 달성을 위한 기간 동안 개인정보를 보유 및 이용합니다.</li>
+          <li>전항에도 불구하고 회사는 내부 방침에 의해 서비스 부정이용기록은 부정 가입 및 이용 방지를 위하여 회원 탈퇴 시점으로부터 최대 1년간 보관합니다.</li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 14조 ( 법령에 따른 개인정보의 보유 및 이용기간 )</h2>
+        <p className="typo-caption-r-2 leading-relaxed">
+          회사는 관계법령에 따라 다음과 같이 개인정보를 보유 및 이용합니다.
+        </p>
+        <ol className="flex list-decimal flex-col gap-3 pl-5 typo-caption-r-2">
+          <li>
+            전자상거래 등에서의 소비자보호에 관한 법률에 따른 보유 정보 및 보유기간
+            <ol className="mt-1 flex list-[lower-alpha] flex-col gap-1 pl-5">
+              <li>계약 또는 청약철회 등에 관한 기록 : 5년</li>
+              <li>대금 결제 및 재화의 공급에 관한 기록 : 5년</li>
+              <li>소비자의 불만 또는 분쟁처리에 관한 기록 : 3년</li>
+              <li>표시, 광고에 관한 기록 : 6개월</li>
+            </ol>
+          </li>
+          <li>
+            통신비밀 보호법에 따른 보유 정보 및 보유기간
+            <ol className="mt-1 flex list-[lower-alpha] flex-col gap-1 pl-5">
+              <li>웹사이트 로그 기록 자료 : 3개월</li>
+            </ol>
+          </li>
+          <li>
+            전자금융 거래법에 따른 보유정보 및 보유 기간
+            <ol className="mt-1 flex list-[lower-alpha] flex-col gap-1 pl-5">
+              <li>전자금융거래에 관한 기록 : 5년</li>
+            </ol>
+          </li>
+          <li>
+            위치정보의 보호 및 이용 등에 관한 법률
+            <ol className="mt-1 flex list-[lower-alpha] flex-col gap-1 pl-5">
+              <li>개인 위치 정보에 관한 기록 : 6개월</li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(legal)/privacy/page.tsx
+++ b/src/app/(legal)/privacy/page.tsx
@@ -1,0 +1,17 @@
+import { createPageMetadata } from '@/utils';
+import { LegalLayout } from '../_components/legal-layout';
+import { PrivacyContent } from './_components';
+
+export const metadata = createPageMetadata({
+  title: 'UNIBUSK 개인정보 처리방침',
+  description: 'UNIBUSK 개인정보 처리방침 전문입니다.',
+  path: '/privacy',
+});
+
+export default function PrivacyPage() {
+  return (
+    <LegalLayout title="UNIBUSK 개인정보 처리방침">
+      <PrivacyContent />
+    </LegalLayout>
+  );
+}

--- a/src/app/(legal)/terms/_components/index.ts
+++ b/src/app/(legal)/terms/_components/index.ts
@@ -1,0 +1,1 @@
+export { TermsContent } from './terms-content';

--- a/src/app/(legal)/terms/_components/terms-content.tsx
+++ b/src/app/(legal)/terms/_components/terms-content.tsx
@@ -1,0 +1,93 @@
+export function TermsContent() {
+  return (
+    <div className="flex flex-col text-gray-700">
+      <section className="flex flex-col">
+        <h2 className="typo-body-sb-3 text-black">제 1조 목적</h2>
+        <p className="typo-caption-r-2 leading-relaxed">
+          본 약관은 두둥스튜디오 (이하 "회사")에서 제공하는 모든 제품 및 서비스(이하 "본 서비스")의
+          이용에 관하여 회사와 본 서비스의 회원 또는 비회원과의 관계를 설명하는 것에 목적이 있습니다.
+          본 서비스를 이용하거나 회원가입을 통해 본 서비스의 회원이 될 경우 본 약관 및 관련 운영 정책을
+          동의하신 것으로 봅니다.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 2조 용어 정의</h2>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>공연 - 행사, 공연 등 모임에 참가자를 모집하기 위한 목적으로 두둥 서비스에 생성하는 콘텐츠를 말합니다.</li>
+          <li>주최자(호스트) - 두둥 서비스에서 공연를 생성하여 다른 여러 회원의 참가 신청을 받는 회원을 말합니다.</li>
+          <li>참가자 - 두둥 서비스의 공연에 티켓 결제 등의 방법으로 참가 신청을 하는 회원을 말합니다.</li>
+          <li>사용자 생성 콘텐츠 - 회원이 직접 본 서비스에서 생성한 게시글, 댓글, 공연 등의 콘텐츠를 말합니다.</li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 3조 약관 동의</h2>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>회원은 본 약관의 규정에 따라 본 서비스를 이용해야 합니다.</li>
+          <li>회원이 미성년자일 경우에는 친권자 등 법정대리인의 동의를 얻은 후 본 서비스를 이용해야합니다.</li>
+          <li>회원이 본 서비스를 사업자를 위해 이용할 경우에는 해당 사업자 역시 본 약관에 동의한 후 서비스를 이용해야 합니다.</li>
+          <li>회사는 개별 서비스에 대해서는 별도의 이용약관 및 정책(개별약관)을 둘 수 있으며, 해당 내용이 이 약관과 상충할 경우에는 개별약관을 우선하여 적용합니다.</li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 4조 약관 변경</h2>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>
+            회사에서 필요하다고 판단할 경우, 회원에 대한 사전 통지 없이 언제라도 본 약관 및 개별 이용약관을
+            변경할 수 있습니다. 변경 후의 본 약관 및 개별 이용약관은 회사가 운영하는 웹사이트 내의 적절한
+            장소에 게시된 시점부터 그 효력이 발생하며, 본 약관 및 개별 이용약관이 변경된 후에도 회원이
+            본 서비스를 계속 이용함으로써 변경 후의 본 약관 및 적용된 개별 이용약관에 대해 유효하고 취소
+            불가능한 동의를 한 것으로 간주됩니다.
+          </li>
+          <li>
+            회원이 변경된 약관에 관하여 동의하지 못할 경우 회사는 회원에게 변경된 약관을 강제로 적용하지
+            않습니다. 다만 회원은 변경된 약관에 대한 동의없이 본 서비스를 이용할 수 없다는 것을 인지해야
+            합니다. 회원은 언제든지 회원탈퇴 신청을 통해 자유롭게 서비스 이용계약 해지가 가능합니다.
+          </li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 5조 이용 계약 성립</h2>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>사용자가 두둥 서비스의 회원가입 기능을 이용하여 필요한 정보를 제출할 시 이용 약관이 체결됩니다.</li>
+        </ol>
+        <p className="typo-caption-r-2 leading-relaxed">
+          회사는 다음 각 호에 해당하는 회원에 관하여 언제든 이용계약을 해지할 수 있습니다. 각 호에 해당하는
+          경우는 보통 약관 위배, 관계 법령 위배, 사회질서 저해에 해당합니다.
+        </p>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>만 14세 미만인 경우</li>
+          <li>타인의 명의를 이용한 경우</li>
+          <li>등록 내용에 허위 정보를 기재하거나 필수 정보가 누락되었을 경우</li>
+          <li>부정한 용도를 목적으로 본 서비스를 이용하는 경우</li>
+          <li>본 서비스가 제공하는 방법 외의 방법으로 영리를 취하려고 하는 경우</li>
+          <li>관계법령에 위배되는 경우</li>
+          <li>사회의 질서 혹은 미풍양속을 저해할 수 있는 사용자 생성 콘텐츠를 업로드하는 경우</li>
+          <li>타인의 권리나 명예를 침해하는 경우</li>
+          <li>본 약관 위배로 회사에 의하여 이용계약이 해지된 경우 (회사에서 재가입 승낙한 경우 제외)</li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 6조 이용 계약 종료</h2>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>회원은 언제든지 회사에게 해지의사를 통지함으로써 이용계약을 해지할 수 있습니다.</li>
+          <li>이용계약은 회원의 해지의사가 회사에 도달한 때에 종료됩니다.</li>
+          <li>회원탈퇴 시 해당 계정의 개인정보는 파기됩니다. 다만 결제기록 등 보관이 필요한 정보는 유지될 수 있습니다. 자세한 내용은 회사의 개인정보처리방침을 참고 바랍니다.</li>
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="typo-body-sb-3 text-black">제 7조 회원의 의무와 책임</h2>
+        <ol className="flex list-decimal flex-col gap-1 pl-5 typo-caption-r-2">
+          <li>회원은 회원 자신의 책임 하에 본 서비스를 이용해야 하며, 본 서비스에서 행한 모든 행위 및 그 결과에 대해서 모든 책임을 져야 합니다.</li>
+          <li>회사는 회원이 본 약관에 위반하는 형태로 본 서비스를 이용하고 있다고 판단되는 경우, 회사에 적절하다고 판단하는 조치를 취합니다. 다만 회사는 이러한 위반 행위를 방지 또는 시정할 의무를 갖지 않습니다.</li>
+          <li>회원의 본 서비스 이용에 있어서, 또는 이러한 이용으로 제 3자로부터 클레임을 받아 회사가 직접적 혹은 간접적으로 어떤 손해를 입었을 경우, 회원은 회사의 요구에 따라 즉시 이를 보상해야 합니다.</li>
+        </ol>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(legal)/terms/page.tsx
+++ b/src/app/(legal)/terms/page.tsx
@@ -1,0 +1,17 @@
+import { createPageMetadata } from '@/utils';
+import { LegalLayout } from '../_components/legal-layout';
+import { TermsContent } from './_components';
+
+export const metadata = createPageMetadata({
+  title: 'UNIBUSK 서비스 약관',
+  description: 'UNIBUSK 서비스 이용약관 전문입니다.',
+  path: '/terms',
+});
+
+export default function TermsPage() {
+  return (
+    <LegalLayout title="UNIBUSK 서비스 약관">
+      <TermsContent />
+    </LegalLayout>
+  );
+}

--- a/src/app/(root)/(auth)/login/page.tsx
+++ b/src/app/(root)/(auth)/login/page.tsx
@@ -34,9 +34,8 @@ export default function LoginPage() {
             카카오로 로그인 하기
           </button>
 
-          {/* TODO: 약관 페이지 구현 후 href 연결 */}
           <Link
-            href="/"
+            href={routePaths.terms()}
             className={`
               inline-flex h-15 items-center justify-center text-gray-400
               transition-colors
@@ -45,9 +44,8 @@ export default function LoginPage() {
             UNIBUSK 서비스 약관
           </Link>
 
-          {/* TODO: 개인정보 처리방침 페이지 구현 후 href 연결 */}
           <Link
-            href="/"
+            href={routePaths.privacy()}
             className={`
               inline-flex h-15 items-center justify-center text-gray-400
               transition-colors

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -4,4 +4,6 @@ export const ROUTES = {
   KAKAO_LOGIN: '/api/auths/login',
   OAUTH_CALLBACK: '/oauth-callback',
   PERFORMANCE_DETAIL: '/performance-detail',
+  TERMS: '/terms',
+  PRIVACY: '/privacy',
 } as const;

--- a/src/utils/route-paths.ts
+++ b/src/utils/route-paths.ts
@@ -22,4 +22,6 @@ export const routePaths = {
   kakaoLogin: () => ROUTES.KAKAO_LOGIN,
   oauthCallback: (provider: string) => `${ROUTES.OAUTH_CALLBACK}/${provider}`,
   performanceDetail: (performanceId: number) => `${ROUTES.PERFORMANCE_DETAIL}/${performanceId}`,
+  terms: () => ROUTES.TERMS,
+  privacy: () => ROUTES.PRIVACY,
 } as const;


### PR DESCRIPTION
## 관련 이슈
Closes #190

## 변경사항

서비스 약관과 개인정보 처리방침 페이지를 구현했습니다.

### 주요 구현
- LegalLayout: 약관 페이지 공통 레이아웃 (제목, 콘텐츠, 확인 버튼)
- TermsPage: 서비스 이용약관 페이지 (/terms)
- PrivacyPage: 개인정보 처리방침 페이지 (/privacy)
- routePaths: terms(), privacy() 라우트 함수 추가
- 로그인 페이지 링크 연결

### 특징
- 반응형 디자인 (모바일/태블릿 최적화)
- SEO 메타데이터 설정
- 재사용 가능한 레이아웃 컴포넌트

## 리뷰 포인트

- 약관 콘텐츠가 올바르게 렌더링되는지 확인
- 반응형 레이아웃이 모바일/태블릿에서 정상 작동하는지 검증
- 확인 버튼 클릭 시 로그인 페이지로 정상 리다이렉트되는지 확인