### PR TITLE
feat: [프로필] 로그아웃 버튼 이벤트 연결

### DIFF
--- a/src/app/profile/_components/profile-info.tsx
+++ b/src/app/profile/_components/profile-info.tsx
@@ -4,6 +4,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { Button } from '@/components/common/button';
 import { AvatarCircleIcon } from '@/components/common/icon';
+import { useAuth } from '@/hooks';
 import { userQueryOptions } from '@/queries/user/user.query';
 import { cn } from '@/utils';
 import { ProfileEditModal } from './profile-edit-modal';
@@ -15,6 +16,8 @@ interface DisplayInputProps {
 
 export function ProfileInfo() {
   const { data: { email, name } } = useSuspenseQuery(userQueryOptions);
+  const { logout } = useAuth();
+
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
@@ -52,7 +55,7 @@ export function ProfileInfo() {
       {/* 이탈 버튼 */}
       <div className="flex gap-2.5">
         <Button theme="lightOrange" size="md">회원탈퇴</Button>
-        <Button theme="gray" size="md">로그아웃</Button>
+        <Button theme="gray" size="md" onClick={async () => await logout()}>로그아웃</Button>
       </div>
 
       {/* 프로필 수정 모달 */}

--- a/src/app/profile/_components/profile-info.tsx
+++ b/src/app/profile/_components/profile-info.tsx
@@ -16,7 +16,7 @@ interface DisplayInputProps {
 
 export function ProfileInfo() {
   const { data: { email, name } } = useSuspenseQuery(userQueryOptions);
-  const { logout } = useAuth();
+  const { logout, isLogoutPending } = useAuth();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -55,7 +55,14 @@ export function ProfileInfo() {
       {/* 이탈 버튼 */}
       <div className="flex gap-2.5">
         <Button theme="lightOrange" size="md">회원탈퇴</Button>
-        <Button theme="gray" size="md" onClick={async () => await logout()}>로그아웃</Button>
+        <Button
+          theme="gray"
+          size="md"
+          disabled={isLogoutPending}
+          onClick={() => void logout()}
+        >
+          로그아웃
+        </Button>
       </div>
 
       {/* 프로필 수정 모달 */}


### PR DESCRIPTION
## 관련 이슈
Closes #181

## 변경사항

프로필 페이지의 로그아웃 버튼에 기능을 연결했습니다.

### 주요 작업
- useAuth 훅에서 logout 함수 가져오기
- 로그아웃 버튼: onClick 핸들러로 logout() 연결
- 클릭 시 세션 종료 및 홈으로 리다이렉트

## 리뷰 포인트

- 로그아웃 버튼 클릭 시 정상 로그아웃되는지 확인
- 쿠키가 정상 삭제되는지 검증
- 홈 페이지로 정상 리다이렉트되는지 확인