### PR TITLE
[공통 컴포넌트] 공연 삭제 재확인 모달 컴포넌트 구현

### DIFF
--- a/src/app/profile/_components/profile-performances.tsx
+++ b/src/app/profile/_components/profile-performances.tsx
@@ -8,7 +8,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useCallback, useRef, useState } from 'react';
 import { Spinner } from '@/components/common/spinner';
-import { PerformanceRegisterButton } from '@/components/performance';
+import { PerformanceDeleteConfirmDialog, PerformanceRegisterButton } from '@/components/performance';
 import { useDeletePerformance } from '@/hooks/performance';
 import { myPerformancesInfiniteQueryOptions } from '@/queries/performance/performance.query';
 import { routePaths } from '@/utils';
@@ -126,166 +126,178 @@ function MyPerformanceCard({
   imageUrls,
 }: MyPerformanceCardProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const { mutate: deleteMyPerformance, isPending: isDeletePending } = useDeletePerformance();
   const { date, time } = formatPerformanceTime(startTime, endTime);
   const thumbnailSrc = imageUrls[0];
 
   return (
-    <Link href={routePaths.performanceDetail(performanceId)}>
-      <div className={`
-        flex w-full items-center rounded-lg bg-white p-2.5 shadow-elevate-2
-      `}
-      >
-        {/* 썸네일 */}
+    <>
+      <Link href={routePaths.performanceDetail(performanceId)}>
         <div className={`
-          relative h-45 w-37.5 shrink-0 overflow-hidden rounded-lg bg-gray-300
+          flex w-full items-center rounded-lg bg-white p-2.5 shadow-elevate-2
         `}
         >
-          {thumbnailSrc && (
-            <Image
-              src={thumbnailSrc}
-              alt={title}
-              fill
-              className="object-cover"
-              sizes="150px"
-            />
-          )}
-        </div>
+          {/* 썸네일 */}
+          <div className={`
+            relative h-45 w-37.5 shrink-0 overflow-hidden rounded-lg bg-gray-300
+          `}
+          >
+            {thumbnailSrc && (
+              <Image
+                src={thumbnailSrc}
+                alt={title}
+                fill
+                className="object-cover"
+                sizes="150px"
+              />
+            )}
+          </div>
 
-        {/* 콘텐츠 */}
-        <div className="flex h-45 flex-1 flex-col justify-center gap-7.5 px-10">
-          {/* 상단: 제목 + 더보기 */}
-          <div className="flex items-center justify-between">
-            <h3 className="typo-body-sb-1 text-black">{title}</h3>
-            <div
-              className="relative"
-              onBlurCapture={(event) => {
-                const nextTarget = event.relatedTarget;
-                if (!(nextTarget instanceof Node)) {
-                  setIsMenuOpen(false);
-                  return;
-                }
-                if (!event.currentTarget.contains(nextTarget)) {
-                  setIsMenuOpen(false);
-                }
-              }}
-            >
-              <button
-                type="button"
-                aria-label="더보기"
-                aria-haspopup="menu"
-                aria-expanded={isMenuOpen}
-                className={`
-                  flex shrink-0 cursor-pointer items-center justify-center
-                  rounded-full p-1.5 transition-colors
-                  hover:bg-gray-100
-                `}
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  setIsMenuOpen(prev => !prev);
+          {/* 콘텐츠 */}
+          <div className={`
+            flex h-45 flex-1 flex-col justify-center gap-7.5 px-10
+          `}
+          >
+            {/* 상단: 제목 + 더보기 */}
+            <div className="flex items-center justify-between">
+              <h3 className="typo-body-sb-1 text-black">{title}</h3>
+              <div
+                className="relative"
+                onBlurCapture={(event) => {
+                  const nextTarget = event.relatedTarget;
+                  if (!(nextTarget instanceof Node)) {
+                    setIsMenuOpen(false);
+                    return;
+                  }
+                  if (!event.currentTarget.contains(nextTarget)) {
+                    setIsMenuOpen(false);
+                  }
                 }}
               >
+                <button
+                  type="button"
+                  aria-label="더보기"
+                  aria-haspopup="menu"
+                  aria-expanded={isMenuOpen}
+                  className={`
+                    flex shrink-0 cursor-pointer items-center justify-center
+                    rounded-full p-1.5 transition-colors
+                    hover:bg-gray-100
+                  `}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setIsMenuOpen(prev => !prev);
+                  }}
+                >
+                  <Image
+                    src="/icons/ellipsisVertical.svg"
+                    alt=""
+                    width={30}
+                    height={30}
+                    aria-hidden="true"
+                    unoptimized
+                  />
+                </button>
+
+                {isMenuOpen && (
+                  <div
+                    role="menu"
+                    aria-label="더보기 메뉴"
+                    className={`
+                      absolute top-[calc(100%+8px)] right-0 z-dropdown w-30
+                      overflow-hidden rounded-[10px] bg-white
+                      shadow-[0_0_4px_rgba(0,0,0,0.25)]
+                    `}
+                  >
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className={`
+                        flex h-12.5 w-full cursor-pointer items-center gap-1.25
+                        border-b border-black/10 p-2.5 typo-caption-r-1
+                        text-black transition-colors
+                        hover:bg-gray-100
+                      `}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setIsMenuOpen(false);
+                      }}
+                    >
+                      <Image
+                        src="/icons/pencilSquare.svg"
+                        alt=""
+                        width={19}
+                        height={19}
+                        aria-hidden="true"
+                        unoptimized
+                      />
+                      수정하기
+                    </button>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      disabled={isDeletePending}
+                      className={`
+                        flex h-12.5 w-full cursor-pointer items-center gap-1.25
+                        p-2.5 typo-caption-r-1 text-black transition-colors
+                        hover:bg-gray-100
+                        disabled:cursor-not-allowed disabled:opacity-50
+                      `}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setIsMenuOpen(false);
+                        setIsDeleteDialogOpen(true);
+                      }}
+                    >
+                      <Image
+                        src="/icons/trashCan.svg"
+                        alt=""
+                        width={19}
+                        height={19}
+                        aria-hidden="true"
+                        unoptimized
+                      />
+                      삭제하기
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* 하단: 날짜/시간 + 장소 */}
+            <div className="flex flex-col gap-1.25">
+              <div className="typo-caption-m-1 text-gray-700">
+                <p>{date}</p>
+                <p>{time}</p>
+              </div>
+              <div className="flex items-center gap-1.25">
                 <Image
-                  src="/icons/ellipsisVertical.svg"
+                  src="/icons/mapPin.svg"
                   alt=""
-                  width={30}
-                  height={30}
+                  width={14}
+                  height={14}
                   aria-hidden="true"
                   unoptimized
                 />
-              </button>
-
-              {isMenuOpen && (
-                <div
-                  role="menu"
-                  aria-label="더보기 메뉴"
-                  className={`
-                    absolute top-[calc(100%+8px)] right-0 z-dropdown w-30
-                    overflow-hidden rounded-[10px] bg-white
-                    shadow-[0_0_4px_rgba(0,0,0,0.25)]
-                  `}
-                >
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={`
-                      flex h-12.5 w-full cursor-pointer items-center gap-1.25
-                      border-b border-black/10 p-2.5 typo-caption-r-1 text-black
-                      transition-colors
-                      hover:bg-gray-100
-                    `}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      setIsMenuOpen(false);
-                    }}
-                  >
-                    <Image
-                      src="/icons/pencilSquare.svg"
-                      alt=""
-                      width={19}
-                      height={19}
-                      aria-hidden="true"
-                      unoptimized
-                    />
-                    수정하기
-                  </button>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    disabled={isDeletePending}
-                    className={`
-                      flex h-12.5 w-full cursor-pointer items-center gap-1.25
-                      p-2.5 typo-caption-r-1 text-black transition-colors
-                      hover:bg-gray-100
-                      disabled:cursor-not-allowed disabled:opacity-50
-                    `}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      setIsMenuOpen(false);
-                      deleteMyPerformance(performanceId);
-                    }}
-                  >
-                    <Image
-                      src="/icons/trashCan.svg"
-                      alt=""
-                      width={19}
-                      height={19}
-                      aria-hidden="true"
-                      unoptimized
-                    />
-                    삭제하기
-                  </button>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* 하단: 날짜/시간 + 장소 */}
-          <div className="flex flex-col gap-1.25">
-            <div className="typo-caption-m-1 text-gray-700">
-              <p>{date}</p>
-              <p>{time}</p>
-            </div>
-            <div className="flex items-center gap-1.25">
-              <Image
-                src="/icons/mapPin.svg"
-                alt=""
-                width={14}
-                height={14}
-                aria-hidden="true"
-                unoptimized
-              />
-              <p className="typo-caption-m-1 text-gray-700">
-                {performanceLocationName}
-              </p>
+                <p className="typo-caption-m-1 text-gray-700">
+                  {performanceLocationName}
+                </p>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </Link>
+      </Link>
+      <PerformanceDeleteConfirmDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        onConfirm={() => deleteMyPerformance(performanceId)}
+        isPending={isDeletePending}
+      />
+    </>
   );
 }
 

--- a/src/components/performance/index.ts
+++ b/src/components/performance/index.ts
@@ -1,2 +1,3 @@
+export { PerformanceDeleteConfirmDialog } from './performance-delete-confirm-dialog';
 export { PerformanceRegisterButton } from './performance-register-button';
 export { RegisterModal } from './register-modal';

--- a/src/components/performance/performance-delete-confirm-dialog.tsx
+++ b/src/components/performance/performance-delete-confirm-dialog.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/common/alert-dialog';
+
+interface PerformanceDeleteConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isPending?: boolean;
+}
+
+export function PerformanceDeleteConfirmDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  isPending = false,
+}: PerformanceDeleteConfirmDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent
+        size="default"
+        className="max-w-238! gap-5 rounded-[20px] border-0 px-20 py-12.5"
+      >
+        <AlertDialogHeader className="gap-5">
+          <AlertDialogTitle className="typo-body-sb-1 text-black">등록한 공연을 삭제하시겠습니까?</AlertDialogTitle>
+          <AlertDialogDescription className="typo-body-m-3 text-black">
+            삭제된 공연 정보는 복구할 수 없으며, 모든 목록에서 삭제됩니다.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex-row items-center justify-center">
+          <AlertDialogCancel theme="gray" appearance="filled" size="md">
+            취소
+          </AlertDialogCancel>
+          <AlertDialogAction
+            theme="orange"
+            appearance="filled"
+            size="md"
+            disabled={isPending}
+            onClick={onConfirm}
+          >
+            삭제하기
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}


### PR DESCRIPTION
## 관련 이슈
Closes #191

## 변경사항

공연 삭제 시 재확인을 위한 모달 컴포넌트를 구현했습니다.

### 주요 구현
- PerformanceDeleteConfirmDialog: AlertDialog 기반 확인 모달
  → Props: open, onOpenChange, onConfirm, isPending
  → 취소/삭제하기 버튼
  → isPending으로 삭제 중 버튼 비활성화
- MyPerformanceCard: 모달 연결
  → 더보기 메뉴 삭제 버튼 클릭 시 모달 표시
  → onConfirm으로 deleteMyPerformance 연결

## 리뷰 포인트

- 모달이 정상 표시되는지 확인
- 취소 버튼 클릭 시 모달이 정상 닫히는지 검증
- 삭제 버튼 클릭 시 공연이 정상 삭제되는지 확인
- isPending 상태에서 버튼이 비활성화되는지 검토

## 추가 정보

현재 shadcn/ui 기본 스타일만 적용된 상태입니다. Issue #199에서 다음 작업을 진행할 예정입니다:
- 모바일 뷰 대응
- 디자인 시스템에 맞춘 커스터마이징