### PR TITLE
fix: container-1920 @utility 미디어 쿼리 CSS 변수 참조 수정 #204

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -261,7 +261,7 @@ body {
   padding-right: 1.25rem; /* 20px */
 
   /* 태블릿 이상에서 패딩 증가 */
-  @media (min-width: var(--breakpoint-md)) {
+  @media (min-width: 768px) {
     padding-left: 2.5rem; /* 40px */
     padding-right: 2.5rem; /* 40px */
   }


### PR DESCRIPTION
## 관련 이슈
Closes #204

## 변경사항

@media 쿼리에서 CSS 변수가 평가되지 않는 문제를 수정했습니다.

### 주요 수정
- `@media (min-width: var(--breakpoint-md))` → `@media (min-width: 768px)`
- 프로덕션 빌드에서 container-1920의 반응형 패딩이 정상 적용됨

## 리뷰 포인트

- 프로덕션 환경에서 container-1920이 적용된 섹션의 패딩이 정상 표시되는지 확인
- 태블릿 이상의 화면에서 레이아웃이 올바르게 렌더링되는지 검증