### PR TITLE
refactor: 더보기 메뉴를 Dropdown 공통 컴포넌트로 마이그레이션 #209

### DIFF
--- a/src/app/profile/_components/profile-performances.tsx
+++ b/src/app/profile/_components/profile-performances.tsx
@@ -138,64 +138,78 @@ function MyPerformanceCard({
 
   return (
     <>
-      <Link href={routePaths.performanceDetail(performanceId)}>
+      <article className={`
+        relative flex w-full items-center rounded-lg bg-white p-2.5
+        shadow-elevate-2
+      `}
+      >
+        {/* 썸네일 */}
         <div className={`
-          flex w-full items-center rounded-lg bg-white p-2.5 shadow-elevate-2
+          relative h-45 w-37.5 shrink-0 overflow-hidden rounded-lg bg-gray-300
         `}
         >
-          {/* 썸네일 */}
-          <div className={`
-            relative h-45 w-37.5 shrink-0 overflow-hidden rounded-lg bg-gray-300
-          `}
-          >
-            {thumbnailSrc && (
-              <Image
-                src={thumbnailSrc}
-                alt={title}
-                fill
-                className="object-cover"
-                sizes="150px"
-              />
-            )}
-          </div>
+          {thumbnailSrc && (
+            <Image
+              src={thumbnailSrc}
+              alt={title}
+              fill
+              className="object-cover"
+              sizes="150px"
+            />
+          )}
+        </div>
 
-          {/* 콘텐츠 */}
-          <div className={`
-            flex h-45 flex-1 flex-col justify-center gap-7.5 px-10
-          `}
-          >
-            {/* 상단: 제목 + 더보기 */}
-            <div className="flex items-center justify-between">
-              <h3 className="typo-body-sb-1 text-black">{title}</h3>
+        {/* 콘텐츠 */}
+        <div className="flex h-45 flex-1 flex-col justify-center gap-7.5 px-10">
+          {/* 상단: 제목 + 더보기 */}
+          <div className="flex items-center justify-between">
+            <h3 className="typo-body-sb-1 text-black">
+              {/*
+                ::after overlay 패턴: 이 <a> 의 ::after 가 <article> 전체를 덮어
+                카드 아무 곳이나 클릭하면 상세로 이동. nesting 없음.
+              */}
+              <Link
+                href={routePaths.performanceDetail(performanceId)}
+                className={`
+                  text-black outline-0
+                  after:absolute after:inset-0 after:content-['']
+                  focus-visible:underline
+                `}
+              >
+                {title}
+              </Link>
+            </h3>
+            {/* z-20: ::after(z-10) 위에 떠야 클릭이 트리거에 닿음 */}
+            <div className="relative z-20">
               <MyPerformanceCardMoreMenu
                 onDeleteClick={() => setIsDeleteDialogOpen(true)}
                 isDeletePending={isDeletePending}
               />
             </div>
+          </div>
 
-            {/* 하단: 날짜/시간 + 장소 */}
-            <div className="flex flex-col gap-1.25">
-              <div className="typo-caption-m-1 text-gray-700">
-                <p>{date}</p>
-                <p>{time}</p>
-              </div>
-              <div className="flex items-center gap-1.25">
-                <Image
-                  src="/icons/mapPin.svg"
-                  alt=""
-                  width={14}
-                  height={14}
-                  aria-hidden="true"
-                  unoptimized
-                />
-                <p className="typo-caption-m-1 text-gray-700">
-                  {performanceLocationName}
-                </p>
-              </div>
+          {/* 하단: 날짜/시간 + 장소 */}
+          <div className="flex flex-col gap-1.25">
+            <div className="typo-caption-m-1 text-gray-700">
+              <p>{date}</p>
+              <p>{time}</p>
+            </div>
+            <div className="flex items-center gap-1.25">
+              <Image
+                src="/icons/mapPin.svg"
+                alt=""
+                width={14}
+                height={14}
+                aria-hidden="true"
+                unoptimized
+              />
+              <p className="typo-caption-m-1 text-gray-700">
+                {performanceLocationName}
+              </p>
             </div>
           </div>
         </div>
-      </Link>
+      </article>
       <PerformanceDeleteConfirmDialog
         open={isDeleteDialogOpen}
         onOpenChange={setIsDeleteDialogOpen}
@@ -211,70 +225,63 @@ export function MyPerformanceCardMoreMenu({
   isDeletePending,
 }: MyPerformanceCardMoreMenuProps) {
   return (
-    <div
-      onClick={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-      }}
-    >
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            aria-label="더보기"
-            className={`
-              cursor-pointer rounded-full p-1.5 outline-0
-              hover:bg-gray-100
-              focus-visible:ring-0 focus-visible:ring-offset-0
-            `}
-          >
-            <Image
-              src="/icons/ellipsisVertical.svg"
-              alt=""
-              width={30}
-              height={30}
-              aria-hidden="true"
-              unoptimized
-            />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="end"
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="더보기"
           className={`
-            w-30 typo-caption-r-1 text-black shadow-[0_0_4px_rgba(0,0,0,0.25)]
-            outline-0
+            cursor-pointer rounded-full p-1.5 outline-0
+            hover:bg-gray-100
+            focus-visible:ring-0 focus-visible:ring-offset-0
           `}
         >
-          <DropdownMenuItem className="cursor-pointer px-2.5 py-[14.5px]">
-            <Image
-              src="/icons/pencilSquare.svg"
-              alt=""
-              width={19}
-              height={19}
-              aria-hidden="true"
-              unoptimized
-            />
-            수정하기
-          </DropdownMenuItem>
-          <DropdownMenuSeparator className="bg-black/10" />
-          <DropdownMenuItem
-            disabled={isDeletePending}
-            className="cursor-pointer px-2.5 py-[14.5px]"
-            onSelect={onDeleteClick}
-          >
-            <Image
-              src="/icons/trashCan.svg"
-              alt=""
-              width={19}
-              height={19}
-              aria-hidden="true"
-              unoptimized
-            />
-            삭제하기
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+          <Image
+            src="/icons/ellipsisVertical.svg"
+            alt=""
+            width={30}
+            height={30}
+            aria-hidden="true"
+            unoptimized
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className={`
+          w-30 typo-caption-r-1 text-black shadow-[0_0_4px_rgba(0,0,0,0.25)]
+          outline-0
+        `}
+      >
+        <DropdownMenuItem className="cursor-pointer px-2.5 py-[14.5px]">
+          <Image
+            src="/icons/pencilSquare.svg"
+            alt=""
+            width={19}
+            height={19}
+            aria-hidden="true"
+            unoptimized
+          />
+          수정하기
+        </DropdownMenuItem>
+        <DropdownMenuSeparator className="bg-black/10" />
+        <DropdownMenuItem
+          disabled={isDeletePending}
+          className="cursor-pointer px-2.5 py-[14.5px]"
+          onSelect={onDeleteClick}
+        >
+          <Image
+            src="/icons/trashCan.svg"
+            alt=""
+            width={19}
+            height={19}
+            aria-hidden="true"
+            unoptimized
+          />
+          삭제하기
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/src/app/profile/_components/profile-performances.tsx
+++ b/src/app/profile/_components/profile-performances.tsx
@@ -7,6 +7,7 @@ import { ko } from 'date-fns/locale';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useCallback, useRef, useState } from 'react';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/common/dropdown-menu';
 import { Spinner } from '@/components/common/spinner';
 import { PerformanceDeleteConfirmDialog, PerformanceRegisterButton } from '@/components/performance';
 import { useDeletePerformance } from '@/hooks/performance';
@@ -27,6 +28,11 @@ interface MyPerformanceCardProps {
   endTime: string;
   performanceLocationName: string;
   imageUrls: string[];
+}
+
+interface MyPerformanceCardMoreMenuProps {
+  onDeleteClick: () => void;
+  isDeletePending: boolean;
 }
 
 function formatPerformanceTime(startTime: string, endTime: string) {
@@ -125,7 +131,6 @@ function MyPerformanceCard({
   performanceLocationName,
   imageUrls,
 }: MyPerformanceCardProps) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const { mutate: deleteMyPerformance, isPending: isDeletePending } = useDeletePerformance();
   const { date, time } = formatPerformanceTime(startTime, endTime);
@@ -162,110 +167,10 @@ function MyPerformanceCard({
             {/* 상단: 제목 + 더보기 */}
             <div className="flex items-center justify-between">
               <h3 className="typo-body-sb-1 text-black">{title}</h3>
-              <div
-                className="relative"
-                onBlurCapture={(event) => {
-                  const nextTarget = event.relatedTarget;
-                  if (!(nextTarget instanceof Node)) {
-                    setIsMenuOpen(false);
-                    return;
-                  }
-                  if (!event.currentTarget.contains(nextTarget)) {
-                    setIsMenuOpen(false);
-                  }
-                }}
-              >
-                <button
-                  type="button"
-                  aria-label="더보기"
-                  aria-haspopup="menu"
-                  aria-expanded={isMenuOpen}
-                  className={`
-                    flex shrink-0 cursor-pointer items-center justify-center
-                    rounded-full p-1.5 transition-colors
-                    hover:bg-gray-100
-                  `}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setIsMenuOpen(prev => !prev);
-                  }}
-                >
-                  <Image
-                    src="/icons/ellipsisVertical.svg"
-                    alt=""
-                    width={30}
-                    height={30}
-                    aria-hidden="true"
-                    unoptimized
-                  />
-                </button>
-
-                {isMenuOpen && (
-                  <div
-                    role="menu"
-                    aria-label="더보기 메뉴"
-                    className={`
-                      absolute top-[calc(100%+8px)] right-0 z-dropdown w-30
-                      overflow-hidden rounded-[10px] bg-white
-                      shadow-[0_0_4px_rgba(0,0,0,0.25)]
-                    `}
-                  >
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className={`
-                        flex h-12.5 w-full cursor-pointer items-center gap-1.25
-                        border-b border-black/10 p-2.5 typo-caption-r-1
-                        text-black transition-colors
-                        hover:bg-gray-100
-                      `}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        setIsMenuOpen(false);
-                      }}
-                    >
-                      <Image
-                        src="/icons/pencilSquare.svg"
-                        alt=""
-                        width={19}
-                        height={19}
-                        aria-hidden="true"
-                        unoptimized
-                      />
-                      수정하기
-                    </button>
-                    <button
-                      type="button"
-                      role="menuitem"
-                      disabled={isDeletePending}
-                      className={`
-                        flex h-12.5 w-full cursor-pointer items-center gap-1.25
-                        p-2.5 typo-caption-r-1 text-black transition-colors
-                        hover:bg-gray-100
-                        disabled:cursor-not-allowed disabled:opacity-50
-                      `}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        setIsMenuOpen(false);
-                        setIsDeleteDialogOpen(true);
-                      }}
-                    >
-                      <Image
-                        src="/icons/trashCan.svg"
-                        alt=""
-                        width={19}
-                        height={19}
-                        aria-hidden="true"
-                        unoptimized
-                      />
-                      삭제하기
-                    </button>
-                  </div>
-                )}
-              </div>
+              <MyPerformanceCardMoreMenu
+                onDeleteClick={() => setIsDeleteDialogOpen(true)}
+                isDeletePending={isDeletePending}
+              />
             </div>
 
             {/* 하단: 날짜/시간 + 장소 */}
@@ -298,6 +203,78 @@ function MyPerformanceCard({
         isPending={isDeletePending}
       />
     </>
+  );
+}
+
+export function MyPerformanceCardMoreMenu({
+  onDeleteClick,
+  isDeletePending,
+}: MyPerformanceCardMoreMenuProps) {
+  return (
+    <div
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+    >
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="더보기"
+            className={`
+              cursor-pointer rounded-full p-1.5 outline-0
+              hover:bg-gray-100
+              focus-visible:ring-0 focus-visible:ring-offset-0
+            `}
+          >
+            <Image
+              src="/icons/ellipsisVertical.svg"
+              alt=""
+              width={30}
+              height={30}
+              aria-hidden="true"
+              unoptimized
+            />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className={`
+            w-30 typo-caption-r-1 text-black shadow-[0_0_4px_rgba(0,0,0,0.25)]
+            outline-0
+          `}
+        >
+          <DropdownMenuItem className="cursor-pointer px-2.5 py-[14.5px]">
+            <Image
+              src="/icons/pencilSquare.svg"
+              alt=""
+              width={19}
+              height={19}
+              aria-hidden="true"
+              unoptimized
+            />
+            수정하기
+          </DropdownMenuItem>
+          <DropdownMenuSeparator className="bg-black/10" />
+          <DropdownMenuItem
+            disabled={isDeletePending}
+            className="cursor-pointer px-2.5 py-[14.5px]"
+            onSelect={onDeleteClick}
+          >
+            <Image
+              src="/icons/trashCan.svg"
+              alt=""
+              width={19}
+              height={19}
+              aria-hidden="true"
+              unoptimized
+            />
+            삭제하기
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }
 

--- a/src/components/common/header/header-auth.tsx
+++ b/src/components/common/header/header-auth.tsx
@@ -1,19 +1,65 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
 import { AvatarButton, Button } from '@/components/common/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/common/dropdown-menu';
 import { useAuth } from '@/hooks/use-auth';
 import { cn } from '@/utils';
-import { LineDivider } from '../line-divider';
 
 interface HeaderAuthProps {
   slotWidthClassName?: string;
 }
 
+interface ProfileDropdownMenuProps {
+  logout: () => Promise<void>;
+  isLogoutPending: boolean;
+}
+
+function ProfileDropdownMenu({ logout, isLogoutPending }: ProfileDropdownMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <AvatarButton
+          size={50}
+          aria-label="사용자 메뉴"
+          className={`
+            outline-0
+            focus-visible:ring-0 focus-visible:ring-offset-0
+          `}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className={`
+          w-37.5 border-gray-300 typo-caption-r-1 text-black
+          shadow-[0_0_10px_rgba(0,0,0,0.15)]
+        `}
+      >
+        <DropdownMenuItem asChild className="cursor-pointer px-2.5 py-5">
+          <Link href="/profile">마이페이지</Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator className="bg-black/10" />
+        <DropdownMenuItem
+          variant="destructive"
+          disabled={isLogoutPending}
+          className="cursor-pointer px-2.5 py-5"
+          onSelect={() => logout()}
+        >
+          로그아웃
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export function HeaderAuth({ slotWidthClassName = 'w-24' }: HeaderAuthProps) {
   const { isAuthenticated, isPending, logout, isLogoutPending } = useAuth();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   if (isPending) {
     return (
@@ -34,76 +80,8 @@ export function HeaderAuth({ slotWidthClassName = 'w-24' }: HeaderAuthProps) {
   }
 
   return (
-    <div
-      className={cn('relative flex items-center justify-end', slotWidthClassName)}
-      onBlurCapture={(event) => {
-        const nextTarget = event.relatedTarget;
-        if (!(nextTarget instanceof Node)) {
-          setIsMenuOpen(false);
-          return;
-        }
-        if (!event.currentTarget.contains(nextTarget)) {
-          setIsMenuOpen(false);
-        }
-      }}
-    >
-      <AvatarButton
-        size={50}
-        aria-label="사용자 메뉴"
-        aria-haspopup="menu"
-        aria-expanded={isMenuOpen}
-        onClick={() => {
-          setIsMenuOpen(prev => !prev);
-        }}
-      />
-
-      {isMenuOpen
-        ? (
-            <div
-              role="menu"
-              aria-label="사용자 메뉴"
-              className={cn(`
-                absolute top-[calc(100%+10px)] right-0 z-dropdown w-37.5
-                overflow-hidden rounded-sm border border-gray-200 bg-white
-                shadow-[0_0_10px_rgba(0,0,0,0.15)]
-              `)}
-            >
-              <Link
-                href="/profile"
-                role="menuitem"
-                className={`
-                  block cursor-pointer px-4 py-3 typo-caption-m-1 text-black
-                  transition-colors
-                  hover:bg-gray-100
-                `}
-                onClick={() => {
-                  setIsMenuOpen(false);
-                }}
-              >
-                마이페이지
-              </Link>
-
-              <LineDivider colorClassName="bg-gray-200" />
-
-              <button
-                type="button"
-                role="menuitem"
-                disabled={isLogoutPending}
-                className={cn(`
-                  block w-full cursor-pointer px-4 py-3 text-left
-                  typo-caption-m-1 text-error transition-colors
-                  hover:bg-gray-100
-                `, isLogoutPending && 'opacity-50')}
-                onClick={async () => {
-                  setIsMenuOpen(false);
-                  await logout();
-                }}
-              >
-                로그아웃
-              </button>
-            </div>
-          )
-        : null}
+    <div className={cn('flex items-center justify-end', slotWidthClassName)}>
+      <ProfileDropdownMenu logout={logout} isLogoutPending={isLogoutPending} />
     </div>
   );
 }


### PR DESCRIPTION
## 관련 이슈
Closes #209

## 변경사항

헤더와 프로필 페이지의 더보기 메뉴를 Dropdown 공통 컴포넌트로 교체했습니다.

### 주요 작업
- header-auth.tsx: ProfileDropdownMenu로 분리 및 Dropdown 컴포넌트 적용
- profile-performances.tsx: MyPerformanceCardMoreMenu로 분리 및 Dropdown 컴포넌트 적용
- isMenuOpen state 및 onBlurCapture 이벤트 제거
- position: absolute 관련 스타일 제거

## 리뷰 포인트

- 더보기 메뉴가 정상 작동하는지 확인
- 메뉴 아이템 클릭 시 정상 실행되는지 검증
- 외부 클릭 시 메뉴가 닫히는지 확인