### PR TITLE
chore: Storybook 뷰포트를 프로젝트 브레이크포인트로 교체

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -17,7 +17,37 @@ const preview: Preview = {
       // 'off' - skip a11y checks entirely
       test: 'todo',
     },
+
+    viewport: {
+      options: {
+        mobile: {
+          name: 'Mobile (< 576px)',
+          styles: { width: '375px', height: '667px' },
+        },
+        sm: {
+          name: 'SM — 576px',
+          styles: { width: '576px', height: '812px' },
+        },
+        md: {
+          name: 'MD — 768px',
+          styles: { width: '768px', height: '1024px' },
+        },
+        lg: {
+          name: 'LG — 1024px',
+          styles: { width: '1024px', height: '100%' },
+        },
+        xl: {
+          name: 'XL — 1200px',
+          styles: { width: '1200px', height: '100%' },
+        },
+      },
+    },
   },
+
+  initialGlobals: {
+    viewport: { value: 'mobile', isRotated: false },
+  },
+
   decorators: [
     Story => (
       <>


### PR DESCRIPTION
## 관련 이슈
Closes #211

## 변경사항

Storybook의 뷰포트를 프로젝트 브레이크포인트와 일치하도록 교체했습니다.

### 주요 작업
- 기본 Storybook 뷰포트 프리셋 제거
- 프로젝트 브레이크포인트 기반 커스텀 뷰포트 추가
  → Mobile: 375px
  → Tablet (sm): 576px
  → Tablet (md): 768px
  → Desktop (lg): 1024px
  → Desktop (xl): 1200px
- 기본 뷰포트: Mobile(375px)로 설정
- Storybook 10 API 적용 (parameters.viewport.options + initialGlobals)

## 리뷰 포인트

- Storybook에서 모든 뷰포트가 정상 선택되는지 확인
- 각 뷰포트에서 컴포넌트 반응형이 정상 작동하는지 검증