### PR TITLE
feat: Button sm size 추가 및 기존 sm을 xs로 변경

### DIFF
--- a/src/app/profile/_components/profile-info.tsx
+++ b/src/app/profile/_components/profile-info.tsx
@@ -42,7 +42,7 @@ export function ProfileInfo() {
         <Button
           theme="orange"
           appearance="outline"
-          size="sm"
+          size="xs"
           className="absolute right-0 mr-91.5"
           onClick={() => setIsModalOpen(true)}
         >

--- a/src/components/common/button/button.stories.tsx
+++ b/src/components/common/button/button.stories.tsx
@@ -50,7 +50,7 @@ export const MediumOrangeFilled: Story = {
   },
 };
 
-/** 3. 디자인 시안: 모바일 확인/취소 버튼 (Small Orange Filled — 120×35px) */
+/** 3. 디자인 시안: 모바일 확인/취소 버튼 (Small Orange Filled — 120×36px) */
 export const SmallOrangeFilled: Story = {
   args: {
     size: 'sm',

--- a/src/components/common/button/button.stories.tsx
+++ b/src/components/common/button/button.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof Button> = {
     },
     size: {
       control: 'select',
-      options: ['lg', 'md', 'sm'],
+      options: ['lg', 'md', 'sm', 'xs'],
       description: '버튼의 크기를 선택합니다. outline 시 크기별로 테두리 두께가 달라집니다.',
     },
   },
@@ -40,23 +40,44 @@ export const LargeOrangeFilled: Story = {
   },
 };
 
-/** 2. 디자인 시안: '장소 찾기' (Small Orange Outline - border 1px) */
-export const SmallOrangeOutline: Story = {
+/** 2. 디자인 시안: 기본 버튼 (Medium Orange Filled) */
+export const MediumOrangeFilled: Story = {
+  args: {
+    size: 'md',
+    theme: 'orange',
+    appearance: 'filled',
+    children: '버튼',
+  },
+};
+
+/** 3. 디자인 시안: 모바일 확인/취소 버튼 (Small Orange Filled — 120×35px) */
+export const SmallOrangeFilled: Story = {
   args: {
     size: 'sm',
+    theme: 'orange',
+    appearance: 'filled',
+    children: '확인',
+  },
+};
+
+/** 4. 디자인 시안: '장소 찾기' (XSmall Orange Outline - border 1px) */
+export const XSmallOrangeOutline: Story = {
+  args: {
+    size: 'xs',
     theme: 'orange',
     appearance: 'outline',
     children: '장소 찾기',
   },
 };
 
-/** 3. 사이즈별 Outline 두께 비교 (lg: 3px, md: 2px, sm: 1px) */
+/** 5. 사이즈별 Outline 두께 비교 (lg: 3px, md: 2px, sm: 1px, xs: 1px) */
 export const OutlineSizeComparison: Story = {
   render: args => (
     <div className="flex flex-col items-center gap-4">
       <Button {...args} size="lg" appearance="outline">Large Outline (3px)</Button>
       <Button {...args} size="md" appearance="outline">Medium Outline (2px)</Button>
       <Button {...args} size="sm" appearance="outline">Small Outline (1px)</Button>
+      <Button {...args} size="xs" appearance="outline">XSmall Outline (1px)</Button>
     </div>
   ),
   args: {
@@ -64,7 +85,7 @@ export const OutlineSizeComparison: Story = {
   },
 };
 
-/** 4. 다양한 색상의 Filled 버튼 조합 */
+/** 6. 다양한 색상의 Filled 버튼 조합 */
 export const ThemeVariants: Story = {
   render: args => (
     <div className="flex items-center gap-4">
@@ -80,7 +101,7 @@ export const ThemeVariants: Story = {
   },
 };
 
-/** 5. 비활성화 상태 */
+/** 7. 비활성화 상태 */
 export const Disabled: Story = {
   args: {
     size: 'md',

--- a/src/components/common/button/button.tsx
+++ b/src/components/common/button/button.tsx
@@ -28,7 +28,7 @@ const buttonVariants = cva(
       size: {
         lg: 'h-15 min-w-87.5 typo-body-sb-1',
         md: 'h-11.25 min-w-37.5 px-7.5 py-2.5 typo-body-m-3',
-        sm: 'h-9 w-30 min-w-0 typo-caption-m-1',
+        sm: 'h-9 min-w-30 typo-caption-m-1',
         xs: 'h-7.5 min-w-25 typo-caption-r-1',
       },
     },

--- a/src/components/common/button/button.tsx
+++ b/src/components/common/button/button.tsx
@@ -28,11 +28,13 @@ const buttonVariants = cva(
       size: {
         lg: 'h-15 min-w-87.5 typo-body-sb-1',
         md: 'h-11.25 min-w-37.5 px-7.5 py-2.5 typo-body-m-3',
-        sm: 'h-7.5 min-w-25 typo-caption-r-1',
+        sm: 'h-9 w-30 min-w-0 typo-caption-m-1',
+        xs: 'h-7.5 min-w-25 typo-caption-r-1',
       },
     },
     compoundVariants: [
       // 1. Outline 상태일 때 사이즈별 테두리 두께 설정
+      { appearance: 'outline', size: 'xs', className: 'border' },
       { appearance: 'outline', size: 'sm', className: 'border' },
       { appearance: 'outline', size: 'md', className: 'border-2' },
       { appearance: 'outline', size: 'lg', className: 'border-[3px]' },
@@ -124,7 +126,7 @@ interface ButtonProps
   asChild?: boolean;
   theme?: 'orange' | 'gray' | 'lightGray' | 'lightOrange';
   appearance?: 'filled' | 'outline';
-  size?: 'lg' | 'md' | 'sm';
+  size?: 'lg' | 'md' | 'sm' | 'xs';
 }
 
 function Button({

--- a/src/components/performance/search-modal.tsx
+++ b/src/components/performance/search-modal.tsx
@@ -75,7 +75,7 @@ export function SearchModal({ onSelect, trigger }: LocationSearchModalProps) {
           <Button
             appearance="outline"
             theme="orange"
-            size="sm"
+            size="xs"
             className="rounded-full px-4 text-xs"
           >
             장소 찾기


### PR DESCRIPTION
## 관련 이슈
Closes #214

## 변경사항

Button 컴포넌트의 size variant를 모바일 디자인 시안에 맞게 개선했습니다.

### 주요 작업
- 신규 sm size 추가 (120×36px, typo-caption-m-1)
- 기존 sm → xs로 변경
- xs outline compoundVariant 추가
- profile-info.tsx, search-modal.tsx: size="sm" → size="xs" 변경

### Storybook
- MediumOrangeFilled, SmallOrangeFilled, XSmallOrangeOutline 스토리 추가
- OutlineSizeComparison에 xs 사이즈 추가

## 리뷰 포인트

- 새로운 sm과 xs 사이즈가 정상 렌더링되는지 확인
- 기존 사용처에서 xs로 변경된 버튼이 정상 작동하는지 검증
- 모바일 뷰에서 새로운 sm 사이즈가 디자인 시안과 일치하는지 검토