### PR TITLE
feat: Button 컴포넌트 반응형 size 지원

### DIFF
--- a/src/components/common/alert-dialog/alert-dialog.stories.tsx
+++ b/src/components/common/alert-dialog/alert-dialog.stories.tsx
@@ -70,22 +70,16 @@ export const Default: Story = {
           <AlertDialogCancel
             theme="gray"
             appearance="filled"
+            mobileSize="sm"
             size="md"
-            className={`
-              h-9 w-30 min-w-0
-              sm:h-11.25 sm:w-auto sm:min-w-37.5
-            `}
           >
             취소
           </AlertDialogCancel>
           <AlertDialogAction
             theme="orange"
             appearance="filled"
+            mobileSize="sm"
             size="md"
-            className={`
-              h-9 w-30 min-w-0
-              sm:h-11.25 sm:w-auto sm:min-w-37.5
-            `}
           >
             확인
           </AlertDialogAction>
@@ -122,16 +116,14 @@ export const Small: Story = {
           <AlertDialogCancel
             theme="gray"
             appearance="filled"
-            size="md"
-            className="h-9 min-w-0"
+            size="sm"
           >
             취소
           </AlertDialogCancel>
           <AlertDialogAction
             theme="orange"
             appearance="filled"
-            size="md"
-            className="h-9 min-w-0"
+            size="sm"
           >
             확인
           </AlertDialogAction>

--- a/src/components/common/alert-dialog/alert-dialog.tsx
+++ b/src/components/common/alert-dialog/alert-dialog.tsx
@@ -183,12 +183,13 @@ function AlertDialogAction({
   className,
   theme,
   size = 'md',
+  mobileSize,
   appearance,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Action>
-  & Pick<React.ComponentProps<typeof Button>, 'size' | 'appearance' | 'theme'>) {
+  & Pick<React.ComponentProps<typeof Button>, 'size' | 'appearance' | 'theme' | 'mobileSize'>) {
   return (
-    <Button theme={theme} size={size} appearance={appearance} asChild className={className}>
+    <Button theme={theme} size={size} mobileSize={mobileSize} appearance={appearance} asChild className={className}>
       <AlertDialogPrimitive.Action
         data-slot="alert-dialog-action"
         {...props}
@@ -201,12 +202,13 @@ function AlertDialogCancel({
   className,
   theme,
   size = 'md',
+  mobileSize,
   appearance,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>
-  & Pick<React.ComponentProps<typeof Button>, 'theme' | 'size' | 'appearance'>) {
+  & Pick<React.ComponentProps<typeof Button>, 'theme' | 'size' | 'appearance' | 'mobileSize'>) {
   return (
-    <Button theme={theme} size={size} appearance={appearance} asChild className={className}>
+    <Button theme={theme} size={size} mobileSize={mobileSize} appearance={appearance} asChild className={className}>
       <AlertDialogPrimitive.Cancel
         data-slot="alert-dialog-cancel"
         {...props}

--- a/src/components/common/button/button.stories.tsx
+++ b/src/components/common/button/button.stories.tsx
@@ -22,7 +22,12 @@ const meta: Meta<typeof Button> = {
     size: {
       control: 'select',
       options: ['lg', 'md', 'sm', 'xs'],
-      description: '버튼의 크기를 선택합니다. outline 시 크기별로 테두리 두께가 달라집니다.',
+      description: '버튼의 크기를 선택합니다. mobileSize가 함께 지정되면 sm(576px) 이상 뷰포트에 적용됩니다.',
+    },
+    mobileSize: {
+      control: 'select',
+      options: [undefined, 'lg', 'md', 'sm', 'xs'],
+      description: '모바일(< 576px) 사이즈. 미지정 시 size를 그대로 사용하며, 지정 시 size는 sm 이상 뷰포트에 적용됩니다.',
     },
   },
 };
@@ -109,5 +114,37 @@ export const Disabled: Story = {
     appearance: 'filled',
     children: '비활성화 버튼',
     disabled: true,
+  },
+};
+
+/**
+ * 8. 반응형 사이즈 대표 데모: mobileSize="sm" + size="lg"
+ * 뷰포트 툴바에서 mobile(375px) ↔ sm(576px) 이상으로 전환하며 확인하세요.
+ * - mobile: 36px(h-9), min-w-120, typo-caption-m-1
+ * - sm 이상: 60px(h-15), min-w-350, typo-body-sb-1
+ */
+export const ResponsiveSmallToLarge: Story = {
+  args: {
+    mobileSize: 'sm',
+    size: 'lg',
+    theme: 'orange',
+    appearance: 'filled',
+    children: '내 공연 등록하기',
+  },
+};
+
+/**
+ * 9. 반응형 Outline 두께 확인: mobileSize="xs" + size="lg"
+ * 사이즈에 짝지어 border 두께도 함께 전환됩니다.
+ * - mobile: border 1px
+ * - sm 이상: border 3px
+ */
+export const ResponsiveOutlineThickness: Story = {
+  args: {
+    mobileSize: 'xs',
+    size: 'lg',
+    theme: 'orange',
+    appearance: 'outline',
+    children: '장소 찾기',
   },
 };

--- a/src/components/common/button/button.tsx
+++ b/src/components/common/button/button.tsx
@@ -5,14 +5,23 @@ import { cn } from '@/utils';
 
 type ButtonSize = 'lg' | 'md' | 'sm' | 'xs';
 
-const SIZE_BASE_CLASSES: Record<ButtonSize, string> = {
+/**
+ * 사이즈 토큰별 클래스 (기본).
+ * 항상 적용되며, mobileSize가 지정된 경우 모바일(< 576px) 사이즈로 사용됩니다.
+ */
+const SIZE_CLASSES_BASE: Record<ButtonSize, string> = {
   lg: 'h-15 min-w-87.5 typo-body-sb-1',
   md: 'h-11.25 min-w-37.5 px-7.5 py-2.5 typo-body-m-3',
   sm: 'h-9 min-w-30 typo-caption-m-1',
   xs: 'h-7.5 min-w-25 typo-caption-r-1',
 };
 
-const SIZE_SM_CLASSES: Record<ButtonSize, string> = {
+/**
+ * 사이즈 토큰별 클래스 (sm 브레이크포인트 이상, >= 576px).
+ * Tailwind JIT가 정적으로 인식하도록 sm: prefix를 명시적으로 적어둡니다.
+ * SIZE_CLASSES_BASE와 동기화 필요 — 토큰 추가/변경 시 양쪽 모두 갱신하세요.
+ */
+const SIZE_CLASSES_SM_UP: Record<ButtonSize, string> = {
   lg: 'sm:h-15 sm:min-w-87.5 sm:typo-body-sb-1',
   md: 'sm:h-11.25 sm:min-w-37.5 sm:px-7.5 sm:py-2.5 sm:typo-body-m-3',
   sm: 'sm:h-9 sm:min-w-30 sm:typo-caption-m-1',
@@ -26,7 +35,7 @@ const OUTLINE_BORDER_BASE: Record<ButtonSize, string> = {
   xs: 'border',
 };
 
-const OUTLINE_BORDER_SM: Record<ButtonSize, string> = {
+const OUTLINE_BORDER_SM_UP: Record<ButtonSize, string> = {
   lg: 'sm:border-[3px]',
   md: 'sm:border-2',
   sm: 'sm:border',
@@ -160,13 +169,13 @@ function Button({
   const Comp = asChild ? Slot : 'button';
 
   const sizeClasses = mobileSize
-    ? cn(SIZE_BASE_CLASSES[mobileSize], SIZE_SM_CLASSES[size])
-    : SIZE_BASE_CLASSES[size];
+    ? cn(SIZE_CLASSES_BASE[mobileSize], SIZE_CLASSES_SM_UP[size])
+    : SIZE_CLASSES_BASE[size];
 
   const borderClasses
     = appearance === 'outline'
       ? mobileSize
-        ? cn(OUTLINE_BORDER_BASE[mobileSize], OUTLINE_BORDER_SM[size])
+        ? cn(OUTLINE_BORDER_BASE[mobileSize], OUTLINE_BORDER_SM_UP[size])
         : OUTLINE_BORDER_BASE[size]
       : '';
 

--- a/src/components/common/button/button.tsx
+++ b/src/components/common/button/button.tsx
@@ -3,6 +3,36 @@ import { Slot } from '@radix-ui/react-slot';
 import { cva } from 'class-variance-authority';
 import { cn } from '@/utils';
 
+type ButtonSize = 'lg' | 'md' | 'sm' | 'xs';
+
+const SIZE_BASE_CLASSES: Record<ButtonSize, string> = {
+  lg: 'h-15 min-w-87.5 typo-body-sb-1',
+  md: 'h-11.25 min-w-37.5 px-7.5 py-2.5 typo-body-m-3',
+  sm: 'h-9 min-w-30 typo-caption-m-1',
+  xs: 'h-7.5 min-w-25 typo-caption-r-1',
+};
+
+const SIZE_SM_CLASSES: Record<ButtonSize, string> = {
+  lg: 'sm:h-15 sm:min-w-87.5 sm:typo-body-sb-1',
+  md: 'sm:h-11.25 sm:min-w-37.5 sm:px-7.5 sm:py-2.5 sm:typo-body-m-3',
+  sm: 'sm:h-9 sm:min-w-30 sm:typo-caption-m-1',
+  xs: 'sm:h-7.5 sm:min-w-25 sm:typo-caption-r-1',
+};
+
+const OUTLINE_BORDER_BASE: Record<ButtonSize, string> = {
+  lg: 'border-[3px]',
+  md: 'border-2',
+  sm: 'border',
+  xs: 'border',
+};
+
+const OUTLINE_BORDER_SM: Record<ButtonSize, string> = {
+  lg: 'sm:border-[3px]',
+  md: 'sm:border-2',
+  sm: 'sm:border',
+  xs: 'sm:border',
+};
+
 const buttonVariants = cva(
   `
     inline-flex shrink-0 cursor-pointer items-center justify-center gap-2
@@ -25,20 +55,8 @@ const buttonVariants = cva(
         filled: '',
         outline: 'bg-transparent',
       },
-      size: {
-        lg: 'h-15 min-w-87.5 typo-body-sb-1',
-        md: 'h-11.25 min-w-37.5 px-7.5 py-2.5 typo-body-m-3',
-        sm: 'h-9 min-w-30 typo-caption-m-1',
-        xs: 'h-7.5 min-w-25 typo-caption-r-1',
-      },
     },
     compoundVariants: [
-      // 1. Outline 상태일 때 사이즈별 테두리 두께 설정
-      { appearance: 'outline', size: 'xs', className: 'border' },
-      { appearance: 'outline', size: 'sm', className: 'border' },
-      { appearance: 'outline', size: 'md', className: 'border-2' },
-      { appearance: 'outline', size: 'lg', className: 'border-[3px]' },
-
       // Orange 조합
       {
         theme: 'orange',
@@ -115,7 +133,6 @@ const buttonVariants = cva(
     defaultVariants: {
       theme: 'orange',
       appearance: 'filled',
-      size: 'md',
     },
   },
 );
@@ -126,19 +143,32 @@ interface ButtonProps
   asChild?: boolean;
   theme?: 'orange' | 'gray' | 'lightGray' | 'lightOrange';
   appearance?: 'filled' | 'outline';
-  size?: 'lg' | 'md' | 'sm' | 'xs';
+  size?: ButtonSize;
+  mobileSize?: ButtonSize;
 }
 
 function Button({
   className,
   theme,
   appearance,
-  size,
+  size = 'md',
+  mobileSize,
   asChild = false,
   disabled,
   ...props
 }: ButtonProps) {
   const Comp = asChild ? Slot : 'button';
+
+  const sizeClasses = mobileSize
+    ? cn(SIZE_BASE_CLASSES[mobileSize], SIZE_SM_CLASSES[size])
+    : SIZE_BASE_CLASSES[size];
+
+  const borderClasses
+    = appearance === 'outline'
+      ? mobileSize
+        ? cn(OUTLINE_BORDER_BASE[mobileSize], OUTLINE_BORDER_SM[size])
+        : OUTLINE_BORDER_BASE[size]
+      : '';
 
   return (
     <Comp
@@ -146,7 +176,9 @@ function Button({
       aria-disabled={disabled}
       disabled={disabled}
       className={cn(
-        buttonVariants({ theme, appearance, size }),
+        buttonVariants({ theme, appearance }),
+        sizeClasses,
+        borderClasses,
         className,
       )}
       {...props}


### PR DESCRIPTION
## 관련 이슈
Closes #198

## 변경사항

Button 컴포넌트에 반응형 size 기능을 추가했습니다.

### 주요 구현
- mobileSize prop 추가
  → sm: 프리픽스로 모바일 사이즈 자동 적용
  → outline 두께도 반응형 동기화
- AlertDialog Action/Cancel: mobileSize forwarding 추가
- Storybook 최신화
  → className 오버라이딩 → mobileSize props로 마이그레이션

## 리뷰 포인트

- mobileSize prop이 정상 작동하는지 확인
- 모바일 뷰에서 사이즈가 올바르게 변경되는지 검증
- 기존 size prop 단독 사용에 영향이 없는지 확인
- AlertDialog에서 mobileSize가 정상 동작하는지 검토