### PR TITLE
refactor: 내가 등록한 공연 삭제 재확인 Dialog에 변경된 AlertDialog 적용

### DIFF
--- a/src/components/common/alert-dialog/alert-dialog.tsx
+++ b/src/components/common/alert-dialog/alert-dialog.tsx
@@ -64,8 +64,8 @@ function AlertDialogContent({
         className={cn(
           `
             group/alert-dialog-content fixed top-[50%] left-[50%] z-modal grid
-            w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%]
-            gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200
+            w-full max-w-[335px] translate-x-[-50%] translate-y-[-50%] gap-4
+            rounded-lg border bg-background p-6 shadow-lg duration-200
             data-[size=sm]:max-w-[335px]
             data-[state=closed]:animate-out data-[state=closed]:fade-out-0
             data-[state=closed]:zoom-out-95

--- a/src/components/performance/performance-delete-confirm-dialog.tsx
+++ b/src/components/performance/performance-delete-confirm-dialog.tsx
@@ -26,23 +26,43 @@ export function PerformanceDeleteConfirmDialog({
 }: PerformanceDeleteConfirmDialogProps) {
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent
-        size="default"
-        className="max-w-238! gap-5 rounded-[20px] border-0 px-20 py-12.5"
+      <AlertDialogContent className={`
+        gap-6 rounded-lg px-10 py-12.5
+        sm:gap-10 sm:px-20
+      `}
       >
-        <AlertDialogHeader className="gap-5">
-          <AlertDialogTitle className="typo-body-sb-1 text-black">등록한 공연을 삭제하시겠습니까?</AlertDialogTitle>
-          <AlertDialogDescription className="typo-body-m-3 text-black">
+        <AlertDialogHeader className={`
+          gap-2.5
+          sm:gap-5
+        `}
+        >
+          <AlertDialogTitle className={`
+            typo-body-sb-3
+            sm:typo-body-sb-1
+          `}
+          >
+            등록한 공연을 삭제하시겠습니까?
+          </AlertDialogTitle>
+          <AlertDialogDescription className={`
+            typo-caption-r-2
+            sm:typo-body-m-3
+          `}
+          >
             삭제된 공연 정보는 복구할 수 없으며, 모든 목록에서 삭제됩니다.
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <AlertDialogFooter className="flex-row items-center justify-center">
-          <AlertDialogCancel theme="gray" appearance="filled" size="md">
+        <AlertDialogFooter className={`
+          gap-1
+          sm:gap-2
+        `}
+        >
+          <AlertDialogCancel theme="gray" appearance="filled" mobileSize="sm" size="md">
             취소
           </AlertDialogCancel>
           <AlertDialogAction
             theme="orange"
             appearance="filled"
+            mobileSize="sm"
             size="md"
             disabled={isPending}
             onClick={onConfirm}


### PR DESCRIPTION
## 관련 이슈
Closes #217

## 변경사항

PerformanceDeleteConfirmDialog에 공통 AlertDialog의 변경 사항을 반영했습니다.

### 주요 작업
- 타이포그래피 반응형 클래스 적용
- AlertDialogCancel, AlertDialogAction: mobileSize="sm" 추가
- 공통 컴포넌트가 처리하는 스타일 오버라이드 제거
- AlertDialogContent 기본 max-width: 335px

## 리뷰 포인트

- 공연 삭제 Dialog가 새로운 스타일과 일치하는지 확인
- 모바일/데스크톱 뷰에서 레이아웃이 정상 표시되는지 검증
- 버튼 크기가 반응형으로 적용되는지 확인