### PR TITLE
feat: 공연 상세 수정/삭제 메뉴 조건부 렌더링

### DIFF
--- a/src/apis/performance/performance.schema.ts
+++ b/src/apis/performance/performance.schema.ts
@@ -116,6 +116,8 @@ export const PerformanceListResponseDtoSchema = z.object({
  * 공연 상세 조회 API 응답 스키마
  */
 export const PerformanceDetailResponseDtoSchema = z.object({
+  /** 유저 고유 ID */
+  memberId: z.number(),
   /** 공연 고유 ID */
   performanceId: z.number(),
   /** 공연 제목 */

--- a/src/app/performance-detail/[performanceId]/_components/performance-info.tsx
+++ b/src/app/performance-detail/[performanceId]/_components/performance-info.tsx
@@ -3,9 +3,20 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { ImageIcon } from 'lucide-react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
 import { Button } from '@/components/common/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/common/dropdown-menu';
+import { PerformanceDeleteConfirmDialog } from '@/components/performance/performance-delete-confirm-dialog';
+import { useDeletePerformance } from '@/hooks/performance/use-delete-performance';
+import { useAuth } from '@/hooks/use-auth';
 import { performanceDetailQueryOptions } from '@/queries/performance';
 import { cn } from '@/utils';
 import { PerformanceLocation } from './performance-location';
@@ -16,8 +27,10 @@ interface PerformanceInfoProps {
 
 export function PerformanceInfo({ performanceId }: PerformanceInfoProps) {
   const { data: performanceDetail } = useSuspenseQuery(performanceDetailQueryOptions(performanceId));
-  const { title, performanceDate, locationName, images, summary, startTime, endTime, performers, description, latitude, longitude } = performanceDetail;
+  const { title, performanceDate, locationName, images, summary, startTime, endTime, performers, description, latitude, longitude, memberId } = performanceDetail;
   const router = useRouter();
+  const { user, isAuthenticated, isPending } = useAuth();
+  const isOwner = !isPending && isAuthenticated && user?.memberId === memberId;
 
   return (
     <section className="pt-37.5">
@@ -26,6 +39,8 @@ export function PerformanceInfo({ performanceId }: PerformanceInfoProps) {
           title={title}
           performanceDate={performanceDate}
           locationName={locationName}
+          isOwner={isOwner}
+          performanceId={performanceId}
         />
       </Suspense>
       <Content
@@ -62,9 +77,11 @@ interface SummaryProps {
   title: string;
   performanceDate: string;
   locationName: string;
+  isOwner: boolean;
+  performanceId: number;
 }
 
-function Summary({ title, performanceDate, locationName }: SummaryProps) {
+function Summary({ title, performanceDate, locationName, isOwner, performanceId }: SummaryProps) {
   const currentTab = useSearchParams().get('tab') ?? 'upcoming';
 
   return (
@@ -89,7 +106,7 @@ function Summary({ title, performanceDate, locationName }: SummaryProps) {
       </div>
 
       {/* 공연 요약 */}
-      <div className="flex items-center gap-5">
+      <div className="flex items-center justify-between gap-5">
         <div className="flex flex-col gap-3.75">
           <h1 className="typo-title-b-3 text-black">{title}</h1>
           <div className="flex items-center gap-5 pb-5">
@@ -100,8 +117,102 @@ function Summary({ title, performanceDate, locationName }: SummaryProps) {
             </span>
           </div>
         </div>
+        {isOwner && <PerformanceOwnerMenu performanceId={performanceId} />}
       </div>
     </div>
+  );
+}
+
+interface PerformanceOwnerMenuProps {
+  performanceId: number;
+}
+
+function PerformanceOwnerMenu({ performanceId }: PerformanceOwnerMenuProps) {
+  const router = useRouter();
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const { mutate, isPending: isDeletePending } = useDeletePerformance();
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="더보기"
+            className={`
+              cursor-pointer rounded-full p-1.5 outline-0
+              hover:bg-gray-100
+              focus-visible:ring-0 focus-visible:ring-offset-0
+            `}
+          >
+            <Image
+              src="/icons/ellipsisVertical.svg"
+              alt=""
+              width={30}
+              height={30}
+              aria-hidden="true"
+              unoptimized
+            />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className={`
+            w-30 typo-caption-r-1 text-black shadow-[0_0_4px_rgba(0,0,0,0.25)]
+            outline-0
+          `}
+        >
+          <DropdownMenuItem
+            asChild
+            className="cursor-pointer px-2.5 py-[14.5px]"
+          >
+            <Link href={`/performance/${performanceId}/edit`}>
+              <Image
+                src="/icons/pencilSquare.svg"
+                alt=""
+                width={19}
+                height={19}
+                aria-hidden="true"
+                unoptimized
+              />
+              수정하기
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator className="bg-black/10" />
+          <DropdownMenuItem
+            disabled={isDeletePending}
+            className="cursor-pointer px-2.5 py-[14.5px]"
+            onSelect={() => setIsDeleteDialogOpen(true)}
+          >
+            <Image
+              src="/icons/trashCan.svg"
+              alt=""
+              width={19}
+              height={19}
+              aria-hidden="true"
+              unoptimized
+            />
+            삭제하기
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <PerformanceDeleteConfirmDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        onConfirm={() =>
+          mutate(performanceId, {
+            onSuccess: () => {
+              if (window.history.length > 1) {
+                router.back();
+              }
+              else {
+                router.push('/performance-list');
+              }
+            },
+          })}
+        isPending={isDeletePending}
+      />
+    </>
   );
 }
 

--- a/src/app/performance-detail/[performanceId]/_components/performance-info.tsx
+++ b/src/app/performance-detail/[performanceId]/_components/performance-info.tsx
@@ -142,7 +142,8 @@ function PerformanceOwnerMenu({ performanceId }: PerformanceOwnerMenuProps) {
             className={`
               cursor-pointer rounded-full p-1.5 outline-0
               hover:bg-gray-100
-              focus-visible:ring-0 focus-visible:ring-offset-0
+              focus-visible:ring-2 focus-visible:ring-primary
+              focus-visible:ring-offset-2
             `}
           >
             <Image

--- a/src/hooks/performance/use-delete-performance.ts
+++ b/src/hooks/performance/use-delete-performance.ts
@@ -1,3 +1,9 @@
+import type { InfiniteData } from '@tanstack/react-query';
+import type {
+  MyPerformanceCursorResponse,
+  PerformanceListResponseDto,
+  PerformanceUpcomingPreviewResponseDto,
+} from '@/apis/performance';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deletePerformance } from '@/apis/performance';
 import { performanceKeys } from '@/queries/performance';
@@ -7,8 +13,41 @@ export function useDeletePerformance() {
 
   return useMutation({
     mutationFn: (performanceId: number) => deletePerformance(performanceId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: performanceKeys.myPerformances() });
+    onSuccess: (_, performanceId) => {
+      queryClient.setQueryData<InfiniteData<MyPerformanceCursorResponse>>(
+        performanceKeys.myPerformances(),
+        (old) => {
+          if (!old)
+            return old;
+          return {
+            ...old,
+            pages: old.pages.map(page => ({
+              ...page,
+              content: page.content.filter(p => p.performanceId !== performanceId),
+            })),
+          };
+        },
+      );
+
+      queryClient.setQueriesData<InfiniteData<PerformanceListResponseDto>>(
+        { queryKey: performanceKeys.lists() },
+        (old) => {
+          if (!old)
+            return old;
+          return {
+            ...old,
+            pages: old.pages.map(page => ({
+              ...page,
+              content: page.content.filter(p => p.performanceId !== performanceId),
+            })),
+          };
+        },
+      );
+
+      queryClient.setQueryData<PerformanceUpcomingPreviewResponseDto>(
+        performanceKeys.upcomingPreview(),
+        old => old?.filter(p => p.performanceId !== performanceId),
+      );
     },
   });
 }


### PR DESCRIPTION
## 관련 이슈
Closes #200

## 변경사항

공연 등록자만 수정/삭제 메뉴를 볼 수 있도록 조건부 렌더링을 구현했습니다.

### 주요 구현
- PerformanceDetailResponseDto: memberId 추가
- useAuth와 memberId 비교로 isOwner 판단
- PerformanceOwnerMenu: DropdownMenu(수정/삭제)와 삭제 확인 모달 캡슐화
- 삭제 성공 후 관련 캐시 즉시 갱신
  → myPerformances, lists, upcomingPreview 쿼리 갱신

## 리뷰 포인트

- 자신이 등록한 공연에서만 메뉴가 표시되는지 확인
- 다른 사용자가 등록한 공연에서 메뉴가 숨겨지는지 검증
- 삭제 성공 후 캐시가 즉시 갱신되는지 확인