### PR TITLE
feat: Sheet 컴포넌트 추가 및 Storybook 작성

### DIFF
--- a/src/components/common/icon/index.ts
+++ b/src/components/common/icon/index.ts
@@ -1,3 +1,4 @@
 export { AvatarCircleIcon } from './avatar-circle';
 export { ChevronLeftIcon, ChevronRightIcon } from './chevron';
 export { SearchIcon } from './search';
+export { XIcon } from './x';

--- a/src/components/common/icon/x.tsx
+++ b/src/components/common/icon/x.tsx
@@ -14,6 +14,7 @@ function XIcon({
 
   return (
     <svg
+      {...props}
       xmlns="http://www.w3.org/2000/svg"
       width="24"
       height="24"
@@ -24,7 +25,6 @@ function XIcon({
       aria-label={ariaLabel}
       aria-labelledby={title ? titleId : ariaLabelledBy}
       className={cn(`block`, className)}
-      {...props}
     >
       {title && <title id={titleId}>{title}</title>}
 

--- a/src/components/common/icon/x.tsx
+++ b/src/components/common/icon/x.tsx
@@ -1,0 +1,38 @@
+import type { SVGProps } from 'react';
+import { useId } from 'react';
+import { cn } from '@/utils';
+
+function XIcon({
+  className,
+  title,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  ...props
+}: SVGProps<SVGSVGElement> & { title?: string }) {
+  const titleId = useId();
+  const hasLabel = Boolean(title || ariaLabel || ariaLabelledBy);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      role="img"
+      aria-hidden={hasLabel ? undefined : true}
+      aria-label={ariaLabel}
+      aria-labelledby={title ? titleId : ariaLabelledBy}
+      className={cn(`block`, className)}
+      {...props}
+    >
+      {title && <title id={titleId}>{title}</title>}
+
+      <path
+        fill="#111"
+        d="M18.97 3.97a.75.75 0 1 1 1.06 1.06L13.06 12l6.97 6.97a.75.75 0 0 1-1.06 1.06L12 13.06l-6.97 6.97a.75.75 0 0 1-1.06-1.06L10.94 12 3.97 5.03a.75.75 0 1 1 1.06-1.06L12 10.94l6.97-6.97Z"
+      />
+    </svg>
+  );
+}
+export { XIcon };

--- a/src/components/common/sheet/index.ts
+++ b/src/components/common/sheet/index.ts
@@ -1,0 +1,1 @@
+export { Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, SheetTrigger } from './sheet';

--- a/src/components/common/sheet/sheet.stories.tsx
+++ b/src/components/common/sheet/sheet.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import type { ReactNode } from 'react';
 import { ChevronLeft, ChevronRight, Menu } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
@@ -235,7 +236,7 @@ export const LocationSearchMobileWithResults: Story = {
   render: () => <LocationSearchWithResults />,
 };
 
-function MobileNavLoggedIn() {
+function MobileNavSheet({ userSection, isLoggedIn }: { userSection: ReactNode; isLoggedIn: boolean }) {
   return (
     <Sheet>
       <header className="flex items-center justify-between px-5 py-4">
@@ -248,7 +249,6 @@ function MobileNavLoggedIn() {
       </header>
 
       <SheetContent side="right" className="w-full gap-0 pt-0" showCloseButton={false}>
-        {/* 헤더 복제 행 — 햄버거가 X로 변한 것처럼 보이게 함 */}
         <div className="flex items-center justify-between px-5 py-4">
           <HeaderLogo />
           <SheetClose asChild>
@@ -258,7 +258,44 @@ function MobileNavLoggedIn() {
           </SheetClose>
         </div>
 
-        {/* 유저 섹션 */}
+        {userSection}
+
+        <nav className="flex flex-col px-5">
+          <p className="py-3 typo-caption-sb-1 text-gray-550">ABOUT US</p>
+          <Link href="/busking-map" className="py-4 typo-body-m-3 text-black">버스킹 맵</Link>
+          <Link
+            href="/performance-list"
+            className="py-4 typo-body-m-3 text-black"
+          >
+            공연 정보
+          </Link>
+          <Link href="/community" className="py-4 typo-body-m-3 text-black">커뮤니티</Link>
+          <hr className="my-2 border-gray-200" />
+          <Link
+            href="/performance/register"
+            className="py-4 typo-body-m-3 text-black"
+          >
+            공연 등록하기
+          </Link>
+          {isLoggedIn && (
+            <button
+              type="button"
+              className="py-4 text-left typo-body-m-3 text-black"
+            >
+              로그아웃
+            </button>
+          )}
+        </nav>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function MobileNavLoggedIn() {
+  return (
+    <MobileNavSheet
+      isLoggedIn
+      userSection={(
         <div className="flex flex-col items-center gap-4 px-5 py-6">
           <div className={`
             flex size-20 items-center justify-center rounded-full bg-gray-200
@@ -286,61 +323,16 @@ function MobileNavLoggedIn() {
             </Button>
           </div>
         </div>
-
-        {/* 내비게이션 */}
-        <nav className="flex flex-col px-5">
-          <p className="py-3 typo-caption-sb-1 text-gray-550">ABOUT US</p>
-          <Link href="/busking-map" className="py-4 typo-body-m-3 text-black">버스킹 맵</Link>
-          <Link
-            href="/performance-list"
-            className="py-4 typo-body-m-3 text-black"
-          >
-            공연 정보
-          </Link>
-          <Link href="/community" className="py-4 typo-body-m-3 text-black">커뮤니티</Link>
-          <hr className="my-2 border-gray-200" />
-          <Link
-            href="/performance/register"
-            className="py-4 typo-body-m-3 text-black"
-          >
-            공연 등록하기
-          </Link>
-          <button
-            type="button"
-            className="py-4 text-left typo-body-m-3 text-black"
-          >
-            로그아웃
-          </button>
-        </nav>
-      </SheetContent>
-    </Sheet>
+      )}
+    />
   );
 }
 
 function MobileNavLoggedOut() {
   return (
-    <Sheet>
-      <header className="flex items-center justify-between px-5 py-4">
-        <HeaderLogo />
-        <SheetTrigger asChild>
-          <button type="button" aria-label="메뉴 열기" className="cursor-pointer">
-            <Menu size={24} />
-          </button>
-        </SheetTrigger>
-      </header>
-
-      <SheetContent side="right" className="w-full gap-0 pt-0" showCloseButton={false}>
-        {/* 헤더 복제 행 */}
-        <div className="flex items-center justify-between px-5 py-4">
-          <HeaderLogo />
-          <SheetClose asChild>
-            <button type="button" aria-label="메뉴 닫기" className="cursor-pointer">
-              <XIcon />
-            </button>
-          </SheetClose>
-        </div>
-
-        {/* 비로그인 유저 섹션 */}
+    <MobileNavSheet
+      isLoggedIn={false}
+      userSection={(
         <div className="flex flex-col items-center gap-4 px-5 py-6">
           <div className={`
             flex size-20 items-center justify-center rounded-full bg-gray-200
@@ -359,34 +351,8 @@ function MobileNavLoggedOut() {
             <Link href="/login">로그인</Link>
           </Button>
         </div>
-
-        {/* 내비게이션 */}
-        <nav className="flex flex-col px-5">
-          <p className="py-3 typo-caption-sb-1 text-gray-550">ABOUT US</p>
-          <Link href="/busking-map" className="py-4 typo-body-m-3 text-black">버스킹 맵</Link>
-          <Link
-            href="/performance-list"
-            className="py-4 typo-body-m-3 text-black"
-          >
-            공연 정보
-          </Link>
-          <Link href="/community" className="py-4 typo-body-m-3 text-black">커뮤니티</Link>
-          <hr className="my-2 border-gray-200" />
-          <Link
-            href="/performance/register"
-            className="py-4 typo-body-m-3 text-black"
-          >
-            공연 등록하기
-          </Link>
-          <button
-            type="button"
-            className="py-4 text-left typo-body-m-3 text-black"
-          >
-            로그아웃
-          </button>
-        </nav>
-      </SheetContent>
-    </Sheet>
+      )}
+    />
   );
 }
 

--- a/src/components/common/sheet/sheet.stories.tsx
+++ b/src/components/common/sheet/sheet.stories.tsx
@@ -1,0 +1,409 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ChevronLeft, ChevronRight, Menu } from 'lucide-react';
+import Link from 'next/link';
+import { useState } from 'react';
+
+import { Button } from '@/components/common/button';
+import { HeaderLogo } from '@/components/common/header/header-logo';
+import { XIcon } from '@/components/common/icon';
+import { AvatarCircleIcon } from '@/components/common/icon/avatar-circle';
+import { Input, Label } from '@/components/common/input';
+import { SearchInput } from '@/components/common/search-input';
+import { SEARCH_EXAMPLES, SEARCH_RESULT_EXAMPLE } from '@/constants/performance';
+import { cn } from '@/utils';
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from './sheet';
+
+const meta: Meta<typeof Sheet> = {
+  title: 'Component/Common/Sheet',
+  component: Sheet,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Sheet>;
+
+/** 모바일 — 프로필 수정 Bottom Sheet */
+export const ProfileEditMobile: Story = {
+  parameters: {
+    viewport: { value: 'mobile' },
+  },
+  render: () => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button
+          theme="orange"
+          appearance="filled"
+          size="sm"
+          className="w-full"
+        >
+          프로필 수정 열기
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="bottom" rounded className="px-5">
+        <SheetHeader align="center">
+          <SheetTitle className="typo-title-b-5">프로필 변경</SheetTitle>
+        </SheetHeader>
+
+        <div className="flex flex-col items-center gap-6 pb-5">
+          <div className="relative">
+            <div className={`
+              flex size-20 items-center justify-center rounded-full bg-gray-200
+            `}
+            >
+              <AvatarCircleIcon className="size-14 text-gray-400" />
+            </div>
+            <div className={`
+              absolute right-0 bottom-0 flex size-6 items-center justify-center
+              rounded-full border border-gray-200 bg-white
+            `}
+            >
+              <span className="text-xs">📷</span>
+            </div>
+          </div>
+
+          <div className="w-full">
+            <Label htmlFor="nickname-mobile">닉네임</Label>
+            <div className="relative">
+              <Input
+                id="nickname-mobile"
+                placeholder="닉네임을 입력해 주세요"
+                maxLength={15}
+                className="pr-12"
+              />
+            </div>
+          </div>
+
+          <SheetClose asChild>
+            <Button
+              theme="orange"
+              appearance="filled"
+              size="md"
+              className="w-50"
+            >
+              변경
+            </Button>
+          </SheetClose>
+
+        </div>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+function LocationSearchDefault() {
+  const [keyword, setKeyword] = useState('');
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button
+          theme="orange"
+          appearance="outline"
+          size="xs"
+          className="rounded-full px-4 text-xs"
+        >
+          장소 찾기
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side="bottom"
+        rounded
+        className="min-h-165 gap-0 px-5 pt-[65px] pb-5"
+      >
+        <SheetHeader align="start" className="p-0 pb-5">
+          <SheetTitle className="typo-body-b-1 text-black">장소를 검색해주세요</SheetTitle>
+        </SheetHeader>
+        <SearchInput
+          value={keyword}
+          onChange={e => setKeyword(e.target.value)}
+          placeholder="예) 걷고싶은거리 버스킹존"
+          className="pb-7.5"
+        />
+        <div className="space-y-5">
+          <p className="typo-caption-r-1 text-primary">아래와 같은 방법으로 검색해보세요!</p>
+          <ul className="space-y-3">
+            {SEARCH_EXAMPLES.map(item => (
+              <li key={item.title} className="typo-caption-m-1 text-black">
+                <span className="block">{item.title}</span>
+                <span className="block pl-1 text-gray-550">{item.example}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function LocationSearchWithResults() {
+  const [keyword, setKeyword] = useState('홍대');
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button
+          theme="orange"
+          appearance="outline"
+          size="xs"
+          className="rounded-full px-4 text-xs"
+        >
+          장소 찾기
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side="bottom"
+        rounded
+        className="max-h-165 gap-0 px-5 pt-[65px] pb-5"
+      >
+        <SheetHeader align="start" className="pb-5">
+          <SheetTitle className="typo-body-b-1">장소를 선택해주세요</SheetTitle>
+        </SheetHeader>
+        <SearchInput
+          value={keyword}
+          onChange={e => setKeyword(e.target.value)}
+          placeholder="예) 걷고싶은거리 버스킹존"
+          className="pb-2.5"
+        />
+        <div className="flex-1 overflow-y-auto">
+          <p className="pb-1.5 typo-caption-sb-1">
+            검색결과 총
+            {' '}
+            <span className="text-primary">38건</span>
+          </p>
+          <div className="divide-y divide-gray-200 border-b border-gray-200">
+            {SEARCH_RESULT_EXAMPLE.slice(0, 4).map(loc => (
+              <div
+                key={loc.id}
+                className={`
+                  cursor-pointer space-y-2.5 py-5 transition-colors
+                  hover:bg-orange-50
+                `}
+              >
+                <p className="typo-caption-sb-1 text-gray-800">{loc.name}</p>
+                <p className="typo-caption-m-1 text-gray-550">{loc.address}</p>
+              </div>
+            ))}
+          </div>
+          <div className={`
+            flex items-center justify-center gap-1 py-4 typo-caption-m-1
+            text-gray-550
+          `}
+          >
+            <button type="button" className="p-1">
+              <ChevronLeft size={16} />
+            </button>
+            {[1, 2, 3, 4].map(page => (
+              <button
+                key={page}
+                type="button"
+                className={cn('px-2 py-1', page === 1 && 'font-bold text-black')}
+              >
+                {page}
+              </button>
+            ))}
+            <button type="button" className="p-1">
+              <ChevronRight size={16} />
+            </button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+/** 모바일 — 장소 검색 Bottom Sheet (초기 상태) */
+export const LocationSearchMobileDefault: Story = {
+  parameters: {
+    viewport: { value: 'mobile' },
+  },
+  render: () => <LocationSearchDefault />,
+};
+
+/** 모바일 — 장소 검색 Bottom Sheet (검색 결과 상태) */
+export const LocationSearchMobileWithResults: Story = {
+  parameters: {
+    viewport: { value: 'mobile' },
+  },
+  render: () => <LocationSearchWithResults />,
+};
+
+function MobileNavLoggedIn() {
+  return (
+    <Sheet>
+      <header className="flex items-center justify-between px-5 py-4">
+        <HeaderLogo />
+        <SheetTrigger asChild>
+          <button type="button" aria-label="메뉴 열기" className="cursor-pointer">
+            <Menu size={24} />
+          </button>
+        </SheetTrigger>
+      </header>
+
+      <SheetContent side="right" className="w-full gap-0 pt-0" showCloseButton={false}>
+        {/* 헤더 복제 행 — 햄버거가 X로 변한 것처럼 보이게 함 */}
+        <div className="flex items-center justify-between px-5 py-4">
+          <HeaderLogo />
+          <SheetClose asChild>
+            <button type="button" aria-label="메뉴 닫기" className="cursor-pointer">
+              <XIcon />
+            </button>
+          </SheetClose>
+        </div>
+
+        {/* 유저 섹션 */}
+        <div className="flex flex-col items-center gap-4 px-5 py-6">
+          <div className={`
+            flex size-20 items-center justify-center rounded-full bg-gray-200
+          `}
+          >
+            <AvatarCircleIcon className="size-20 text-gray-400" />
+          </div>
+          <p className="pb-5 typo-body-m-3">날아다니는 우주 4606</p>
+          <div className="flex w-full gap-3">
+            <Button
+              appearance="outline"
+              theme="lightGray"
+              size="md"
+              className="flex-1"
+            >
+              마이페이지
+            </Button>
+            <Button
+              appearance="outline"
+              theme="lightGray"
+              size="md"
+              className="flex-1"
+            >
+              내가 등록한 공연
+            </Button>
+          </div>
+        </div>
+
+        {/* 내비게이션 */}
+        <nav className="flex flex-col px-5">
+          <p className="py-3 typo-caption-sb-1 text-gray-550">ABOUT US</p>
+          <Link href="/busking-map" className="py-4 typo-body-m-3 text-black">버스킹 맵</Link>
+          <Link
+            href="/performance-list"
+            className="py-4 typo-body-m-3 text-black"
+          >
+            공연 정보
+          </Link>
+          <Link href="/community" className="py-4 typo-body-m-3 text-black">커뮤니티</Link>
+          <hr className="my-2 border-gray-200" />
+          <Link
+            href="/performance/register"
+            className="py-4 typo-body-m-3 text-black"
+          >
+            공연 등록하기
+          </Link>
+          <button
+            type="button"
+            className="py-4 text-left typo-body-m-3 text-black"
+          >
+            로그아웃
+          </button>
+        </nav>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function MobileNavLoggedOut() {
+  return (
+    <Sheet>
+      <header className="flex items-center justify-between px-5 py-4">
+        <HeaderLogo />
+        <SheetTrigger asChild>
+          <button type="button" aria-label="메뉴 열기" className="cursor-pointer">
+            <Menu size={24} />
+          </button>
+        </SheetTrigger>
+      </header>
+
+      <SheetContent side="right" className="w-full gap-0 pt-0" showCloseButton={false}>
+        {/* 헤더 복제 행 */}
+        <div className="flex items-center justify-between px-5 py-4">
+          <HeaderLogo />
+          <SheetClose asChild>
+            <button type="button" aria-label="메뉴 닫기" className="cursor-pointer">
+              <XIcon />
+            </button>
+          </SheetClose>
+        </div>
+
+        {/* 비로그인 유저 섹션 */}
+        <div className="flex flex-col items-center gap-4 px-5 py-6">
+          <div className={`
+            flex size-20 items-center justify-center rounded-full bg-gray-200
+          `}
+          >
+            <AvatarCircleIcon className="size-20 text-gray-400" />
+          </div>
+          <p className="pb-5 typo-body-m-3">로그인 해 주세요</p>
+          <Button
+            appearance="filled"
+            theme="orange"
+            size="md"
+            asChild
+            className="w-50"
+          >
+            <Link href="/login">로그인</Link>
+          </Button>
+        </div>
+
+        {/* 내비게이션 */}
+        <nav className="flex flex-col px-5">
+          <p className="py-3 typo-caption-sb-1 text-gray-550">ABOUT US</p>
+          <Link href="/busking-map" className="py-4 typo-body-m-3 text-black">버스킹 맵</Link>
+          <Link
+            href="/performance-list"
+            className="py-4 typo-body-m-3 text-black"
+          >
+            공연 정보
+          </Link>
+          <Link href="/community" className="py-4 typo-body-m-3 text-black">커뮤니티</Link>
+          <hr className="my-2 border-gray-200" />
+          <Link
+            href="/performance/register"
+            className="py-4 typo-body-m-3 text-black"
+          >
+            공연 등록하기
+          </Link>
+          <button
+            type="button"
+            className="py-4 text-left typo-body-m-3 text-black"
+          >
+            로그아웃
+          </button>
+        </nav>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+/** 모바일 — 헤더 네비게이션 Right Sheet (로그인 상태) */
+export const MobileNavMenuLoggedIn: Story = {
+  parameters: {
+    viewport: { value: 'mobile' },
+    layout: 'fullscreen',
+  },
+  render: () => <MobileNavLoggedIn />,
+};
+
+/** 모바일 — 헤더 네비게이션 Right Sheet (비로그인 상태) */
+export const MobileNavMenuLoggedOut: Story = {
+  parameters: {
+    viewport: { value: 'mobile' },
+    layout: 'fullscreen',
+  },
+  render: () => <MobileNavLoggedOut />,
+};

--- a/src/components/common/sheet/sheet.tsx
+++ b/src/components/common/sheet/sheet.tsx
@@ -117,7 +117,7 @@ function SheetContent({
           `}
           >
             <XIcon className="size-5.5" />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">닫기</span>
           </SheetPrimitive.Close>
         )}
       </SheetPrimitive.Content>

--- a/src/components/common/sheet/sheet.tsx
+++ b/src/components/common/sheet/sheet.tsx
@@ -1,0 +1,194 @@
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import * as React from 'react';
+
+import { cn } from '@/utils/index';
+import { XIcon } from '../icon';
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        `
+          fixed inset-0 z-modal-backdrop bg-black/50
+          data-[state=closed]:animate-out data-[state=closed]:fade-out-0
+          data-[state=open]:animate-in data-[state=open]:fade-in-0
+        `,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  side = 'right',
+  rounded = false,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  rounded?: boolean;
+  showCloseButton?: boolean;
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          `
+            fixed z-modal flex flex-col gap-5 bg-background shadow-lg transition
+            ease-in-out
+            data-[state=closed]:animate-out data-[state=closed]:duration-300
+            data-[state=open]:animate-in data-[state=open]:duration-500
+          `,
+          side === 'right'
+          && `
+            inset-y-0 right-0 h-full w-3/4 border-l
+            data-[state=closed]:slide-out-to-right
+            data-[state=open]:slide-in-from-right
+            sm:max-w-sm
+          `,
+          side === 'left'
+          && `
+            inset-y-0 left-0 h-full w-3/4 border-r
+            data-[state=closed]:slide-out-to-left
+            data-[state=open]:slide-in-from-left
+            sm:max-w-sm
+          `,
+          side === 'top'
+          && `
+            inset-x-0 top-0 h-auto border-b
+            data-[state=closed]:slide-out-to-top
+            data-[state=open]:slide-in-from-top
+          `,
+          side === 'bottom'
+          && `
+            inset-x-0 bottom-0 h-auto border-t
+            data-[state=closed]:slide-out-to-bottom
+            data-[state=open]:slide-in-from-bottom
+          `,
+          rounded && side === 'right' && 'rounded-tl-2xl rounded-bl-2xl',
+          rounded && side === 'left' && 'rounded-tr-2xl rounded-br-2xl',
+          rounded && side === 'top' && 'rounded-br-2xl rounded-bl-2xl',
+          rounded && side === 'bottom' && 'rounded-tl-2xl rounded-tr-2xl',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close className={`
+            absolute top-5 right-6.5 cursor-pointer rounded-full opacity-70
+            ring-offset-background transition-opacity
+            hover:opacity-100
+            focus:ring-2 focus:ring-ring focus:ring-offset-2
+            focus:outline-hidden
+            disabled:pointer-events-none
+            data-[state=open]:bg-secondary
+          `}
+          >
+            <XIcon className="size-5.5" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  );
+}
+
+function SheetHeader({
+  className,
+  align = 'center',
+  ...props
+}: React.ComponentProps<'div'> & {
+  align?: 'start' | 'center' | 'end';
+}) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn(
+        'flex flex-col gap-1.5 p-4',
+        align === 'center' && 'items-center',
+        align === 'end' && 'items-end',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn('font-semibold text-black', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn('text-sm text-black', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+};


### PR DESCRIPTION
## 관련 이슈
Closes #220

## 변경사항

공통 Sheet 컴포넌트를 추가하고 Storybook을 작성했습니다.

### 주요 구현
- Sheet: Radix UI Dialog 기반
  → side/rounded/showCloseButton props 지원
  → SheetHeader, SheetTitle, SheetFooter, SheetClose 등 서브 컴포넌트
- XIcon: 새로운 아이콘 컴포넌트 추가

### Storybook
- ProfileEditMobile: 프로필 수정 Bottom Sheet
- LocationSearchMobileDefault/WithResults: 장소 검색 Bottom Sheet
- MobileNavMenuLoggedIn/LoggedOut: 헤더 네비게이션 Right Sheet

## 리뷰 포인트

- Sheet가 정상 열리고 닫히는지 확인
- 모바일 뷰에서 Bottom Sheet가 올바르게 표시되는지 검증
- Right Sheet의 위치와 스타일이 디자인과 일치하는지 검토
- 각 Story에서 실제 UI가 정상 렌더링되는지 확인