### PR TITLE
chore: pnpm 워크스페이스 설정 및 의존성 downgrade 문제 해결

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  semver@<7: ^7.6.3
+
 importers:
 
   .:
@@ -6118,10 +6121,6 @@ packages:
     resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
     engines: {node: ^14.0.0 || >=16.0.0}
 
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
@@ -8091,7 +8090,7 @@ snapshots:
       debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8109,7 +8108,7 @@ snapshots:
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.28.1
       lru-cache: 5.1.1
-      semver: 6.3.1
+      semver: 7.7.3
 
   '@babel/helper-globals@7.28.0': {}
 
@@ -11909,7 +11908,7 @@ snapshots:
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
-      semver: 6.3.1
+      semver: 7.7.3
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
@@ -12136,7 +12135,7 @@ snapshots:
       object.values: 1.2.1
       prop-types: 15.8.1
       resolve: 2.0.0-next.5
-      semver: 6.3.1
+      semver: 7.7.3
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
@@ -14082,8 +14081,6 @@ snapshots:
       '@eslint-community/regexpp': 4.12.2
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
-
-  semver@6.3.1: {}
 
   semver@7.7.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,15 @@
+minimumReleaseAge: 1440 # 1 day
+
 shellEmulator: true
 
 trustPolicy: no-downgrade
 
 packages:
   - .
+
+overrides:
+  semver@<7: ^7.6.3
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver


### PR DESCRIPTION
## 관련 이슈
Closes #226

## 변경사항

pnpm 워크스페이스를 구성하고 의존성 downgrade 문제를 해결했습니다.

### 주요 작업
- pnpm-workspace.yaml 설정 구성
- minimumReleaseAge: 1440분 설정 (최신 배포 패키지 즉시 설치 차단)
- semver override: ^7.6.3 설정 (ERR_PNPM_TRUST_DOWNGRADE 해결)
- lockfile 업데이트 (semver@6.3.1 제거, 7.7.3으로 교체)

## 리뷰 포인트

- pnpm install이 정상 작동하는지 확인
- 의존성 downgrade 에러가 해결되었는지 검증