### PR TITLE
feat: useMediaQuery hook 구현

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useAuth } from './use-auth';
+export { useMediaQuery } from './use-media-query';

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 
 /**
  * CSS 미디어 쿼리 결과를 구독하는 훅. 쿼리 조건의 참/거짓이 바뀔 때만 리렌더됩니다.
@@ -19,14 +19,14 @@ import { useSyncExternalStore } from 'react';
  * const isTouchDevice = useMediaQuery('(hover: none) and (pointer: coarse)');
  */
 export function useMediaQuery(query: string): boolean {
-  return useSyncExternalStore(
-    (callback) => {
-      const media = window.matchMedia(query);
-      media.addEventListener('change', callback);
+  const subscribe = useCallback((callback: () => void) => {
+    const media = window.matchMedia(query);
+    media.addEventListener('change', callback);
 
-      return () => media.removeEventListener('change', callback);
-    },
-    () => window.matchMedia(query).matches,
-    () => false,
-  );
+    return () => media.removeEventListener('change', callback);
+  }, [query]);
+
+  const getSnapshot = useCallback(() => window.matchMedia(query).matches, [query]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
 }

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * CSS 미디어 쿼리 결과를 구독하는 훅. 쿼리 조건의 참/거짓이 바뀔 때만 리렌더됩니다.
+ *
+ * @param query - 표준 CSS 미디어 쿼리 문자열
+ * @returns 쿼리가 현재 뷰포트에 일치하면 `true`, 아니면 `false`
+ *
+ * @example
+ * // 단일 브레이크포인트
+ * const isMobile = useMediaQuery('(max-width: 767px)');
+ *
+ * @example
+ * // 범위 지정
+ * const isTablet = useMediaQuery('(min-width: 768px) and (max-width: 1023px)');
+ *
+ * @example
+ * // 기기 특성 감지
+ * const isTouchDevice = useMediaQuery('(hover: none) and (pointer: coarse)');
+ */
+export function useMediaQuery(query: string): boolean {
+  return useSyncExternalStore(
+    (callback) => {
+      const media = window.matchMedia(query);
+      media.addEventListener('change', callback);
+
+      return () => media.removeEventListener('change', callback);
+    },
+    () => window.matchMedia(query).matches,
+    () => false,
+  );
+}


### PR DESCRIPTION
## 관련 이슈
Closes #231

## 변경사항

CSS 반응형만으로는 표현할 수 없는 모바일/데스크톱 완전 분기 UI를 지원하는 useMediaQuery hook을 구현했습니다.

### 주요 구현
- useSyncExternalStore 기반으로 MediaQueryList 상태 구독
- change 이벤트 감지하여 미디어 쿼리 상태 실시간 반영
- getServerSnapshot으로 SSR 안전성 확보 (hydration mismatch 방지)

## 리뷰 포인트

- hook이 정상 작동하는지 확인
- 브레이크포인트 기준 렌더링 분기가 정상 작동하는지 검증
- SSR 환경에서 hydration mismatch가 발생하지 않는지 확인
- 리사이즈 이벤트 시 상태가 즉시 업데이트되는지 검증