### PR TITLE
fix: 한글 사이트명 '유니버스크' 검색 노출 보완

### DIFF
--- a/src/app/(main)/_components/home-hero-section.tsx
+++ b/src/app/(main)/_components/home-hero-section.tsx
@@ -32,7 +32,7 @@ export function HomeHeroSection({ mapBgSrc, heroIllustSrc }: HomeHeroSectionProp
         <MainLayout className="relative z-10 pt-20">
           <div className="grid grid-cols-12 items-center gap-6">
             <div className="col-span-5">
-              <h1 className={`
+              <h2 className={`
                 typo-title-b-1 leading-[1.15] font-bold tracking-[-0.02em]
                 text-gray-900
               `}
@@ -40,7 +40,7 @@ export function HomeHeroSection({ mapBgSrc, heroIllustSrc }: HomeHeroSectionProp
                 누구나 거리 위에서
                 <br />
                 공연을 시작할 수 있도록
-              </h1>
+              </h2>
 
               <p className={`
                 mt-6 typo-title-r-4 leading-[1.6] whitespace-nowrap

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -4,16 +4,17 @@ import { getHomeOrganizationJsonLd, getHomeWebsiteJsonLd, HOME_DESCRIPTION } fro
 import { HomeFooter, HomeHeroSection, HomePromoSection, HomeUpcomingBuskingSection } from './_components';
 
 export const metadata = createPageMetadata({
-  title: 'HOME',
+  title: '',
   description: HOME_DESCRIPTION,
   path: '/',
 });
 
-export default function Page() {
+export default function HomePage() {
   return (
     <main className="w-full">
       <JsonLdScript id="website-json-ld" data={getHomeWebsiteJsonLd()} />
       <JsonLdScript id="organization-json-ld" data={getHomeOrganizationJsonLd()} />
+      <h1 className="sr-only">UNIBUSK 유니버스크 - 버스킹 공연 일정과 장소 플랫폼</h1>
       <section className={`
         min-h-250 w-full
         bg-[radial-gradient(circle_at_center,#FAFAFA_0%,#FFF7F2CC_100%)]

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,11 +16,13 @@ const pretendard = localFont({
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
+  applicationName: 'UNIBUSK(유니버스크)',
   title: {
     template: '%s | UNIBUSK',
-    default: 'UNIBUSK',
+    default: 'UNIBUSK(유니버스크)',
   },
-  description: '공연이 만들어지고, 보여지고, 시작되는 곳. 버스킹의 모든 순간을 잇다, UNIBUSK',
+  description: '공연이 만들어지고, 보여지고, 시작되는 곳. 버스킹의 모든 순간을 잇다, UNIBUSK(유니버스크)',
+  keywords: ['UNIBUSK', '유니버스크', '버스킹', '거리공연', '공연정보', '버스킹지도'],
   icons: {
     icon: '/logos/small-logo-unibusk-primary.png',
   },

--- a/src/utils/seo/home-json-ld.ts
+++ b/src/utils/seo/home-json-ld.ts
@@ -2,13 +2,16 @@ import type { Organization, WebSite, WithContext } from 'schema-dts';
 import { SITE_URL } from '@/constants';
 import { toAbsoluteUrl } from './site-url';
 
-export const HOME_DESCRIPTION = 'UNIBUSK에서 버스킹 공연 일정과 장소를 찾고, 다가오는 공연 정보를 확인해보세요.';
+export const HOME_SITE_NAME = 'UNIBUSK';
+export const HOME_DESCRIPTION = 'UNIBUSK(유니버스크)에서 버스킹 공연 일정과 장소를 찾고, 다가오는 공연 정보를 확인해보세요.';
+export const HOME_ALTERNATE_NAME = '유니버스크';
 
 export function getHomeWebsiteJsonLd(): WithContext<WebSite> {
   return {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
-    'name': 'UNIBUSK',
+    'name': HOME_SITE_NAME,
+    'alternateName': HOME_ALTERNATE_NAME,
     'url': SITE_URL,
     'description': HOME_DESCRIPTION,
     'inLanguage': 'ko-KR',
@@ -19,9 +22,10 @@ export function getHomeOrganizationJsonLd(): WithContext<Organization> {
   return {
     '@context': 'https://schema.org',
     '@type': 'Organization',
-    'name': 'UNIBUSK',
+    'name': HOME_SITE_NAME,
+    'alternateName': HOME_ALTERNATE_NAME,
     'url': SITE_URL,
     'logo': toAbsoluteUrl('/logos/logo-unibusk-stacked-vertical.png'),
-    'description': '공연이 만들어지고, 보여지고, 시작되는 곳. 버스킹의 모든 순간을 잇다, UNIBUSK',
+    'description': '공연이 만들어지고, 보여지고, 시작되는 곳. 버스킹의 모든 순간을 잇다, UNIBUSK(유니버스크)',
   };
 }


### PR DESCRIPTION
## 관련 이슈

<!-- 이슈 번호를 입력하세요. -->

Closes #237 


<!-- 주요 변경사항을 작성하세요. -->
## 변경사항

- 전역 metadata에 한글 브랜드명 `유니버스크` 반영
  - `applicationName`, `title.default`, `keywords` 보완

- 홈 SEO 정보 개선
  - 홈 title을 `HOME`에서 `UNIBUSK(유니버스크)` 중심으로 변경
  - description에 한글 브랜드명 포함

- 홈 본문에 `유니버스크` 텍스트 추가
  - 검색엔진이 실제 페이지 콘텐츠에서도 한글 브랜드명을 인식할 수 있도록 보완

- 홈 JSON-LD 구조화 데이터 보완
  - `WebSite`, `Organization`에 `alternateName: '유니버스크'` 추가


## 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->
- 전역 metadata에 들어간 한글 브랜드명 표기가 적절한지 확인
