### PR TITLE
perf: 공연 등록 멀티 스텝 폼 리렌더 범위 최소화

### DIFF
--- a/src/components/common/input/input.tsx
+++ b/src/components/common/input/input.tsx
@@ -56,7 +56,7 @@ function Label({
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   error?: string;
   showCount?: boolean;
-  currentCount?: number;
+  currentCount?: React.ReactNode;
   /** Input 컴포넌트의 최상위 래퍼 div에 적용될 클래스 */
   containerClassName?: string;
 }

--- a/src/components/performance/steps/step-01.tsx
+++ b/src/components/performance/steps/step-01.tsx
@@ -1,64 +1,101 @@
 'use client';
 
 import type { PerformanceRegisterForm } from '@/apis/performance';
-import { Controller, useFormContext } from 'react-hook-form';
+import { useFormContext, useFormState, useWatch } from 'react-hook-form';
 import { FormInput } from '@/components/common/input';
 import { formatPhoneNumber } from '@/utils';
 
-export function Step01() {
-  const { register, control, watch, formState: { errors } } = useFormContext<PerformanceRegisterForm>();
-  const teamName = watch('teamName');
+function TeamNameCharCount() {
+  const teamName = useWatch<PerformanceRegisterForm, 'teamName'>({ name: 'teamName' });
+
+  return <>{teamName?.length ?? 0}</>;
+}
+
+function TeamNameField() {
+  const { register } = useFormContext<PerformanceRegisterForm>();
+  const { errors } = useFormState<PerformanceRegisterForm>({ name: 'teamName' });
 
   return (
+    <div className="max-w-146.5 space-y-2">
+      <FormInput
+        label="팀 이름"
+        required
+        placeholder="팀명 또는 활동명을 적어주세요"
+        error={errors.teamName?.message}
+        {...register('teamName')}
+        showCount
+        maxLength={20}
+        currentCount={<TeamNameCharCount />}
+      />
+    </div>
+  );
+}
+
+function ContactNumberField() {
+  const { register } = useFormContext<PerformanceRegisterForm>();
+  const { errors } = useFormState<PerformanceRegisterForm>({ name: 'contactNumber' });
+  const contactNumberProps = register('contactNumber');
+
+  return (
+    <div className="flex-1 space-y-2">
+      <FormInput
+        {...contactNumberProps}
+        label="공연자 전화번호"
+        required
+        placeholder="전화번호를 적어주세요"
+        error={errors.contactNumber?.message}
+        inputMode="tel"
+        onChange={(e) => {
+          e.target.value = formatPhoneNumber(e.target.value);
+          contactNumberProps.onChange(e);
+        }}
+      />
+    </div>
+  );
+}
+
+function EmailField() {
+  const { register } = useFormContext<PerformanceRegisterForm>();
+  const { errors } = useFormState<PerformanceRegisterForm>({ name: 'email' });
+
+  return (
+    <div className="flex-1 space-y-2">
+      <FormInput
+        label="공연자 이메일"
+        required
+        placeholder="이메일을 적어주세요"
+        error={errors.email?.message}
+        {...register('email')}
+      />
+    </div>
+  );
+}
+
+function InstagramField() {
+  const { register } = useFormContext<PerformanceRegisterForm>();
+  const { errors } = useFormState<PerformanceRegisterForm>({ name: 'instagramUrl' });
+
+  return (
+    <div className="w-[calc(50%-0.75rem)] space-y-2">
+      <FormInput
+        label="인스타그램"
+        placeholder="인스타그램 URL을 입력해주세요"
+        error={errors.instagramUrl?.message}
+        {...register('instagramUrl')}
+      />
+    </div>
+  );
+}
+
+export function Step01() {
+  return (
     <div className="flex flex-col gap-6">
-      <div className="max-w-146.5 space-y-2">
-        <FormInput
-          label="팀 이름"
-          required
-          placeholder="팀명 또는 활동명을 적어주세요"
-          error={errors.teamName?.message}
-          {...register('teamName')}
-          showCount
-          maxLength={20}
-          currentCount={teamName?.length || 0}
-        />
-      </div>
+      <TeamNameField />
       <div className="flex w-full gap-6">
-        <div className="flex-1 space-y-2">
-          <Controller
-            name="contactNumber"
-            control={control}
-            render={({ field }) => (
-              <FormInput
-                {...field}
-                label="공연자 전화번호"
-                required
-                placeholder="전화번호를 적어주세요"
-                error={errors.contactNumber?.message}
-                inputMode="tel"
-                onChange={e => field.onChange(formatPhoneNumber(e.target.value))}
-              />
-            )}
-          />
-        </div>
-        <div className="flex-1 space-y-2">
-          <FormInput
-            label="공연자 이메일"
-            required
-            placeholder="이메일을 적어주세요"
-            error={errors.email?.message}
-            {...register('email')}
-          />
-        </div>
+        <ContactNumberField />
+        <EmailField />
       </div>
-      <div className="w-[calc(50%-0.75rem)] space-y-2">
-        <FormInput
-          label="인스타그램"
-          placeholder="인스타그램 URL을 입력해주세요"
-          error={errors.instagramUrl?.message}
-          {...register('instagramUrl')}
-        />
-      </div>
+      <InstagramField />
     </div>
   );
 }

--- a/src/components/performance/steps/step-02.tsx
+++ b/src/components/performance/steps/step-02.tsx
@@ -2,7 +2,7 @@
 
 import type { Control } from 'react-hook-form';
 import type { PerformanceRegisterForm } from '@/apis/performance';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, useFormContext, useFormState } from 'react-hook-form';
 import { DatePicker } from '@/components/common/date-picker/date-picker';
 import { ErrorMessage, FormInput, Input, Label } from '@/components/common/input';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/common/select';
@@ -15,123 +15,126 @@ interface TimeSelectProps {
   name: 'startTime' | 'endTime';
   label: string;
   options: string[];
-  error?: boolean;
 }
 
-export function Step02() {
-  const { control, setValue, register, formState: { errors } } = useFormContext<PerformanceRegisterForm>();
+function PerformanceNameField() {
+  const { register } = useFormContext<PerformanceRegisterForm>();
+  const { errors } = useFormState<PerformanceRegisterForm>({ name: 'performanceName' });
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex w-full items-center gap-6">
-        <div className="flex-1">
-          <FormInput
-            label="공연 이름"
-            required
-            placeholder="공연 이름을 적어주세요"
-            error={errors.performanceName?.message}
-            {...register('performanceName')}
-          />
-        </div>
+    <FormInput
+      label="공연 이름"
+      required
+      placeholder="공연 이름을 적어주세요"
+      error={errors.performanceName?.message}
+      {...register('performanceName')}
+    />
+  );
+}
 
-        <div className="flex-1">
+function PerformanceLocationField() {
+  const { control, setValue } = useFormContext<PerformanceRegisterForm>();
+
+  return (
+    <Controller
+      control={control}
+      name="performanceLocation"
+      render={({ field, fieldState: { error } }) => (
+        <div>
           <div className="mb-2.5 flex items-center justify-between pl-2.5">
             <div className="flex items-center gap-1.25">
               <label className="typo-body-sb-2 text-black">
                 <span className="pr-0.5 text-error">*</span>
                 공연 장소
               </label>
-              <ErrorMessage message={errors.performanceLocation?.message} />
+              <ErrorMessage message={error?.message} />
             </div>
             <SearchModal
               onSelect={loc => setValue('performanceLocation', loc, { shouldValidate: true })}
             />
           </div>
-          <Controller
-            control={control}
-            name="performanceLocation"
-            render={({ field }) => (
-              <Input
-                placeholder="공연 장소를 등록해 주세요"
-                readOnly
-                value={field.value?.name || ''}
-                error={errors.performanceLocation?.message}
-              />
-            )}
+          <Input
+            placeholder="공연 장소를 등록해 주세요"
+            readOnly
+            value={field.value?.name || ''}
+            error={error?.message}
           />
         </div>
-      </div>
+      )}
+    />
+  );
+}
 
-      <div className="flex w-full gap-6">
-        <div className="flex-1">
-          <Controller
-            control={control}
-            name="performanceDate"
-            render={({ field: { value, onChange }, fieldState: { error } }) => (
-              <DatePicker
-                label="공연 날짜"
-                required
-                placeholder="날짜 선택"
-                value={value}
-                onChange={onChange}
-                error={!!error}
-                errorMessage={error?.message}
-              />
-            )}
-          />
-        </div>
+function PerformanceDateField() {
+  const { control } = useFormContext<PerformanceRegisterForm>();
 
-        <div className="flex-1">
-          <FormInput
-            label="공연 한 줄 설명"
-            required
-            placeholder="간단한 공연 설명을 적어주세요"
-            error={errors.performanceDescription?.message}
-            {...register('performanceDescription')}
-          />
-        </div>
-      </div>
+  return (
+    <Controller
+      control={control}
+      name="performanceDate"
+      render={({ field: { value, onChange }, fieldState: { error } }) => (
+        <DatePicker
+          label="공연 날짜"
+          required
+          placeholder="날짜 선택"
+          value={value}
+          onChange={onChange}
+          error={!!error}
+          errorMessage={error?.message}
+        />
+      )}
+    />
+  );
+}
 
-      <div className="w-full space-y-4">
-        <Label required error={errors.startTime?.message || errors.endTime?.message}>
-          공연 시간
-        </Label>
-        <div className="flex items-center gap-3">
-          <TimeSelect
-            control={control}
-            name="startTime"
-            label="시작"
-            options={TIME_OPTIONS}
-            error={!!errors.startTime}
-          />
-          <TimeSelect
-            control={control}
-            name="endTime"
-            label="종료"
-            options={TIME_OPTIONS}
-            error={!!errors.endTime}
-          />
-        </div>
+function PerformanceDescriptionField() {
+  const { register } = useFormContext<PerformanceRegisterForm>();
+  const { errors } = useFormState<PerformanceRegisterForm>({ name: 'performanceDescription' });
+
+  return (
+    <FormInput
+      label="공연 한 줄 설명"
+      required
+      placeholder="간단한 공연 설명을 적어주세요"
+      error={errors.performanceDescription?.message}
+      {...register('performanceDescription')}
+    />
+  );
+}
+
+function PerformanceTimeField() {
+  const { control } = useFormContext<PerformanceRegisterForm>();
+  const { errors } = useFormState<PerformanceRegisterForm>({ name: ['startTime', 'endTime'] });
+
+  return (
+    <div className="w-full space-y-4">
+      <Label required error={errors.startTime?.message || errors.endTime?.message}>
+        공연 시간
+      </Label>
+      <div className="flex items-center gap-3">
+        <TimeSelect control={control} name="startTime" label="시작" options={TIME_OPTIONS} />
+        <TimeSelect control={control} name="endTime" label="종료" options={TIME_OPTIONS} />
       </div>
     </div>
   );
 }
 
-function TimeSelect({ control, name, label, options, error }: TimeSelectProps) {
+function TimeSelect({ control, name, label, options }: TimeSelectProps) {
+  const triggerId = `time-select-${name}`;
+
   return (
     <div className="flex items-center">
-      <label
-        htmlFor="select-time"
-        className="p-5 typo-body-m-3 text-gray-800"
-      >
+      <label htmlFor={triggerId} className="p-5 typo-body-m-3 text-gray-800">
         {label}
       </label>
+
       <Controller
         control={control}
         name={name}
-        render={({ field: { value, onChange } }) => (
+        render={({ field: { value, onChange }, fieldState: { error } }) => (
           <Select value={value} onValueChange={onChange} variant="time">
             <SelectTrigger
+              id={triggerId}
               className={cn('w-27.5 cursor-pointer', error && 'border-error')}
               showIcon={false}
             >
@@ -154,6 +157,32 @@ function TimeSelect({ control, name, label, options, error }: TimeSelectProps) {
           </Select>
         )}
       />
+    </div>
+  );
+}
+
+export function Step02() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex w-full items-center gap-6">
+        <div className="flex-1">
+          <PerformanceNameField />
+        </div>
+        <div className="flex-1">
+          <PerformanceLocationField />
+        </div>
+      </div>
+
+      <div className="flex w-full gap-6">
+        <div className="flex-1">
+          <PerformanceDateField />
+        </div>
+        <div className="flex-1">
+          <PerformanceDescriptionField />
+        </div>
+      </div>
+
+      <PerformanceTimeField />
     </div>
   );
 }

--- a/src/components/performance/steps/step-03.tsx
+++ b/src/components/performance/steps/step-03.tsx
@@ -1,67 +1,87 @@
 'use client';
 
 import type { PerformanceRegisterForm } from '@/apis/performance';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, useFormContext, useFormState, useWatch } from 'react-hook-form';
 import { ImageUpload } from '@/components/common/image-upload/image-upload';
 import { Label } from '@/components/common/input';
 import { cn } from '@/utils';
 
-export function Step03() {
-  const { control, register, watch, formState: { errors } } = useFormContext<PerformanceRegisterForm>();
-  const performanceDetail = watch('performanceDetail');
+function PosterImageField() {
+  const { control } = useFormContext<PerformanceRegisterForm>();
+  const { errors } = useFormState<PerformanceRegisterForm>({ name: 'posterImage' });
 
   return (
-    <div className="flex gap-3.75">
-      <div className="w-57.5 space-y-2">
-        <Label>공연 포스터</Label>
-        <Controller
-          control={control}
-          name="posterImage"
-          render={({ field: { onChange, value } }) => (
-            <ImageUpload
-              onFileChange={onChange}
-              defaultImageUrl={value instanceof File ? URL.createObjectURL(value) : undefined}
-              className={cn('h-70 w-55', errors.posterImage && `
-                rounded-xl border border-error
-              `)}
-            />
-          )}
-        />
-        <div className="typo-caption-r-2 whitespace-pre-wrap text-gray-500">
-          <span className="block">이미지 권장 사이즈는 1080 × 1440 px입니다.</span>
-          <span className="block">또한 형식은 JPG, JPEG, PNG</span>
-          <span className="block">용량은 10MB 미만의 이미지만 가능합니다.</span>
-        </div>
-      </div>
-
-      <div className="flex flex-1 flex-col space-y-2">
-        <Label required error={errors.performanceDetail?.message}>공연 상세 내용</Label>
-        <div className="relative flex-1">
-          <textarea
-            className={cn(
-              `
-                h-full w-full resize-none rounded-lg border-none bg-gray-100 p-6
-                typo-body-m-3 text-black
-                focus:border-gray-700 focus:ring-1 focus:outline-none
-              `,
-              errors.performanceDetail && `
-                ring-1 ring-error
-                focus:ring-error
-              `,
-            )}
-            {...register('performanceDetail')}
+    <div className="w-57.5 space-y-2">
+      <Label>공연 포스터</Label>
+      <Controller
+        control={control}
+        name="posterImage"
+        render={({ field: { onChange, value } }) => (
+          <ImageUpload
+            onFileChange={onChange}
+            defaultImageUrl={value instanceof File ? URL.createObjectURL(value) : undefined}
+            className={cn('h-70 w-55', errors.posterImage && `
+              rounded-xl border border-error
+            `)}
           />
-          {!performanceDetail && (
-            <div className={`
-              pointer-events-none absolute inset-0 flex items-center
-              justify-center
-            `}
-            >
-              <span className="typo-body-m-3 text-gray-550">공연에 대한 상세 내용을 작성해 주세요</span>
-            </div>
-          )}
-        </div>
+        )}
+      />
+      <div className="typo-caption-r-2 whitespace-pre-wrap text-gray-500">
+        <span className="block">이미지 권장 사이즈는 1080 × 1440 px입니다.</span>
+        <span className="block">또한 형식은 JPG, JPEG, PNG</span>
+        <span className="block">용량은 10MB 미만의 이미지만 가능합니다.</span>
       </div>
+    </div>
+  );
+}
+
+function PerformanceDetailPlaceholder() {
+  const performanceDetail = useWatch<PerformanceRegisterForm, 'performanceDetail'>({ name: 'performanceDetail' });
+  if (performanceDetail)
+    return null;
+  return (
+    <div className={`
+      pointer-events-none absolute inset-0 flex items-center justify-center
+    `}
+    >
+      <span className="typo-body-m-3 text-gray-550">공연에 대한 상세 내용을 작성해 주세요</span>
+    </div>
+  );
+}
+
+function PerformanceDetailField() {
+  const { register } = useFormContext<PerformanceRegisterForm>();
+  const { errors } = useFormState<PerformanceRegisterForm>({ name: 'performanceDetail' });
+
+  return (
+    <div className="flex flex-1 flex-col space-y-2">
+      <Label required error={errors.performanceDetail?.message}>공연 상세 내용</Label>
+      <div className="relative flex-1">
+        <textarea
+          className={cn(
+            `
+              h-full w-full resize-none rounded-lg border-none bg-gray-100 p-6
+              typo-body-m-3 text-black
+              focus:border-gray-700 focus:ring-1 focus:outline-none
+            `,
+            errors.performanceDetail && `
+              ring-1 ring-error
+              focus:ring-error
+            `,
+          )}
+          {...register('performanceDetail')}
+        />
+        <PerformanceDetailPlaceholder />
+      </div>
+    </div>
+  );
+}
+
+export function Step03() {
+  return (
+    <div className="flex gap-3.75">
+      <PosterImageField />
+      <PerformanceDetailField />
     </div>
   );
 }

--- a/src/components/performance/steps/step-04.tsx
+++ b/src/components/performance/steps/step-04.tsx
@@ -3,13 +3,88 @@
 import type { PerformanceRegisterForm } from '@/apis/performance';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import Image from 'next/image';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, useFormContext, useFormState } from 'react-hook-form';
 import { CHECKLIST_ITEMS } from '@/constants/performance';
 import { cn } from '@/utils';
 
-export function Step04() {
-  const { control, formState: { errors } } = useFormContext<PerformanceRegisterForm>();
+function ChecklistField() {
+  const { control } = useFormContext<PerformanceRegisterForm>();
 
+  return (
+    <Controller
+      control={control}
+      name="checklist"
+      render={({ field }) => (
+        <div className="flex flex-col gap-7.5">
+          {CHECKLIST_ITEMS.map((item) => {
+            const isChecked = Array.isArray(field.value) && field.value.includes(item.id);
+
+            return (
+              <div key={item.id} className="flex items-center gap-2.5">
+                <CheckboxPrimitive.Root
+                  id={item.id}
+                  checked={isChecked}
+                  onCheckedChange={(checked) => {
+                    const currentValue = Array.isArray(field.value) ? field.value : [];
+                    if (checked) {
+                      field.onChange([...currentValue, item.id]);
+                    }
+                    else {
+                      field.onChange(currentValue.filter(id => id !== item.id));
+                    }
+                  }}
+                  className={`
+                    flex h-8 w-8 cursor-pointer items-center justify-center
+                    rounded-full outline-none
+                    focus-visible:ring-2 focus-visible:ring-primary
+                  `}
+                >
+                  <Image
+                    src={
+                      isChecked
+                        ? '/icons/checkCircle-selected-orange.svg'
+                        : '/icons/checkCircle-gray.svg'
+                    }
+                    width={32}
+                    height={32}
+                    alt="check"
+                  />
+                </CheckboxPrimitive.Root>
+
+                <label
+                  htmlFor={item.id}
+                  className={cn(
+                    'cursor-pointer typo-body-m-1 transition-colors',
+                    isChecked
+                      ? 'text-gray-700'
+                      : 'text-gray-550',
+                  )}
+                >
+                  {item.text}
+                </label>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    />
+  );
+}
+
+function ChecklistError() {
+  const { errors } = useFormState<PerformanceRegisterForm>({ name: 'checklist' });
+  if (!errors.checklist) {
+    return null;
+  }
+
+  return (
+    <p className="pt-5.25 text-center typo-caption-r-1 text-error">
+      {errors.checklist.message}
+    </p>
+  );
+}
+
+export function Step04() {
   return (
     <>
       <div className={`
@@ -17,70 +92,9 @@ export function Step04() {
         py-12.5
       `}
       >
-        <Controller
-          control={control}
-          name="checklist"
-          render={({ field }) => (
-            <div className="flex flex-col gap-7.5">
-              {CHECKLIST_ITEMS.map((item) => {
-                const isChecked = Array.isArray(field.value) && field.value.includes(item.id);
-
-                return (
-                  <div key={item.id} className="flex items-center gap-2.5">
-                    <CheckboxPrimitive.Root
-                      id={item.id}
-                      checked={isChecked}
-                      onCheckedChange={(checked) => {
-                        const currentValue = Array.isArray(field.value) ? field.value : [];
-                        if (checked) {
-                          field.onChange([...currentValue, item.id]);
-                        }
-                        else {
-                          field.onChange(currentValue.filter(id => id !== item.id));
-                        }
-                      }}
-                      className={`
-                        flex h-8 w-8 cursor-pointer items-center justify-center
-                        rounded-full outline-none
-                        focus-visible:ring-2 focus-visible:ring-primary
-                      `}
-                    >
-                      <Image
-                        src={
-                          isChecked
-                            ? '/icons/checkCircle-selected-orange.svg'
-                            : '/icons/checkCircle-gray.svg'
-                        }
-                        width={32}
-                        height={32}
-                        alt="check"
-                      />
-                    </CheckboxPrimitive.Root>
-
-                    <label
-                      htmlFor={item.id}
-                      className={cn(
-                        'cursor-pointer typo-body-m-1 transition-colors',
-                        isChecked
-                          ? 'text-gray-700'
-                          : 'text-gray-550',
-                      )}
-                    >
-                      {item.text}
-                    </label>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        />
+        <ChecklistField />
       </div>
-
-      {errors.checklist && (
-        <p className="pt-5.25 text-center typo-caption-r-1 text-error">
-          {errors.checklist.message}
-        </p>
-      )}
+      <ChecklistError />
     </>
   );
 }


### PR DESCRIPTION
## 관련 이슈
Closes #239

## 변경사항

RHF의 비제어 컴포넌트 설계 의도대로 입력 중인 필드만 리렌더되도록 개선했습니다.

### 개선 전
<img width="347" height="549" alt="init" src="https://github.com/user-attachments/assets/e7371cfb-b244-4054-a026-c4e09fc8c4d1" />

### 핵심 개선

#### 1. watch() → useWatch() 분리
`watch()`를 구독 범위를 최소화한 `useWatch()` 분리 컴포넌트로 교체합니다.

<table>
  <tr>
    <td>
      <img width="587" alt="watch-to-useWatch" src="https://github.com/user-attachments/assets/22cb6f25-5438-4ac8-bf04-70c9dbba65e7" />
    </td>
    <td>
      <img width="586" alt="watch-to-useWatch-space" src="https://github.com/user-attachments/assets/a0132a74-ff12-48fe-b532-8001790cfd18" />
    </td>
  </tr>
</table>


#### 2. 필드 컴포넌트 분리
각 필드를 독립 컴포넌트로 분리하고 `useFormState({ name })` 로컬 구독으로 해당 필드만 리렌더합니다.

<table>
  <tr>
    <td>
      <img width="584" alt="use-watch-separate-component" src="https://github.com/user-attachments/assets/d4b64838-6721-49ce-a748-15ca72420ac1" />
    </td>
    <td>
      <img width="584" alt="use-watch-separate-component-space" src="https://github.com/user-attachments/assets/e0badc4d-82b1-402d-9647-ac63769302ce" />
    </td>
  </tr>
</table>


### 최종 결과

<table>
  <tr>
    <td>
      <img width="583" alt="final-step01" src="https://github.com/user-attachments/assets/31238884-2928-41e8-a40f-8dd602ae81f9" />
    </td>
    <td>
      <img width="584" alt="final-step01-space" src="https://github.com/user-attachments/assets/e0badc4d-82b1-402d-9647-ac63769302ce" />
    </td>
  </tr>
</table>

### 성능 개선 효과
**최적화 전**: 입력 시 75개 컴포넌트 리렌더링
**최적화 후**: 입력한 Input Field 1개만 리렌더링

### 스텝별 최적화
- Step 01: TeamNameCharCount에 useWatch 격리, 잘못 사용된 Controller ➡️ register로 마이그레이션
- Step 02: 독립 컴포넌트로 분리하고 useFormState({ name }) 로컬 구독 적용
- Step 03: PerformanceDetailPlaceholder에 useWatch 격리
- Step 04: ChecklistError에 useFormState 격리

## 리뷰 포인트

- 각 필드 입력 시 해당 필드만 리렌더되는지 확인
- React DevTools Profiler로 리렌더 범위 개선 확인
- 폼 제출 시 모든 데이터가 정상 수집되는지 검증