### PR TITLE
hotfix: 홈 페이지 탭 제목 노출 방식 수정

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,13 +1,34 @@
+import type { Metadata } from 'next';
 import { JsonLdScript } from '@/components/seo';
-import { createPageMetadata } from '@/utils';
+import { SHARED_OPEN_GRAPH } from '@/utils';
 import { getHomeOrganizationJsonLd, getHomeWebsiteJsonLd, HOME_DESCRIPTION } from '@/utils/seo';
 import { HomeFooter, HomeHeroSection, HomePromoSection, HomeUpcomingBuskingSection } from './_components';
 
-export const metadata = createPageMetadata({
-  title: '',
+const HOME_TITLE = 'UNIBUSK';
+const HOME_OG_IMAGE = '/logos/logo-unibusk-stacked-vertical.webp';
+
+export const metadata: Metadata = {
+  title: {
+    absolute: HOME_TITLE,
+  },
   description: HOME_DESCRIPTION,
-  path: '/',
-});
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    ...SHARED_OPEN_GRAPH,
+    title: HOME_TITLE,
+    description: HOME_DESCRIPTION,
+    url: '/',
+    images: [HOME_OG_IMAGE],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: HOME_TITLE,
+    description: HOME_DESCRIPTION,
+    images: [HOME_OG_IMAGE],
+  },
+};
 
 export default function HomePage() {
   return (


### PR DESCRIPTION
## 관련 이슈

<!-- 이슈 번호를 입력하세요. -->

Closes #241 

## 변경사항

<!-- 주요 변경사항을 작성하세요. -->
- 홈페이지 탭 제목이 `| UNIBUSK`로 노출되던 문제를 수정
    - 홈페이지 탭 제목이 브랜드명만 단독으로 노출되도록 조정
    - canonical 정보 정리
    - Open Graph, Twitter 제목도 홈 페이지 기준으로 일관되게 정리

## 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->
- 홈페이지 접속 시 브라우저 탭 제목이 `UNIBUSK`로 보이는지 확인

## 추가 정보

<!-- 스크린샷, 테스트 방법 등 추가 정보가 있다면 작성하세요 -->
- 로컬에서 확인
<img width="227" height="43" alt="image" src="https://github.com/user-attachments/assets/08a1a6c4-079c-4254-b2ec-8253e4339bb5" />
