### PR TITLE
feat: 홈 페이지 반응형 레이아웃 적용

### DIFF
--- a/src/app/(main)/_components/home-footer.tsx
+++ b/src/app/(main)/_components/home-footer.tsx
@@ -2,9 +2,21 @@ import { MainLayout } from '@/components/layout';
 
 export function HomeFooter() {
   return (
-    <footer className="w-full border-t border-gray-100 bg-white py-14">
-      <MainLayout>
-        <div className="flex items-start justify-between gap-12">
+    <footer className={`
+      w-full border-t border-gray-100 bg-white py-10
+      md:py-14
+    `}
+    >
+      <MainLayout className={`
+        px-5
+        md:px-6
+      `}
+      >
+        <div className={`
+          flex flex-col gap-8
+          md:flex-row md:items-start md:justify-between md:gap-12
+        `}
+        >
           <div className="flex items-center gap-3">
             <span className={`
               text-title-4 font-bold tracking-tight text-primary
@@ -15,7 +27,11 @@ export function HomeFooter() {
           </div>
 
           <div className="flex-1">
-            <div className="mt-6 typo-caption-r-2 leading-[1.7] text-gray-500">
+            <div className={`
+              typo-caption-r-2 leading-[1.7] break-keep text-gray-500
+              md:mt-6
+            `}
+            >
               <div>유니버스크 | 사업자 상가구분번호 000 0000 0000</div>
               <div>대표: 000 | TEL: 0507-1111-1111 | Email: unibusk@gmail.com</div>
               <div>사업자 번호: 000-00-00000 | 통신판매업 신고번호: 0000-XXXX-0000</div>

--- a/src/app/(main)/_components/home-hero-section.tsx
+++ b/src/app/(main)/_components/home-hero-section.tsx
@@ -27,69 +27,112 @@ export function HomeHeroSection({ mapBgSrc, heroIllustSrc }: HomeHeroSectionProp
   };
 
   return (
-    <section className="w-full bg-[#FFFDFB]">
-      <div className="relative mx-auto min-h-250 w-full max-w-480">
-        <MainLayout className="relative z-10 pt-20">
-          <div className="grid grid-cols-12 items-center gap-6">
-            <div className="col-span-5">
-              <h2 className={`
-                typo-title-b-1 leading-[1.15] font-bold tracking-[-0.02em]
-                text-gray-900
+    <section className={`
+      w-full bg-[radial-gradient(circle_at_center,#FAFAFA_0%,#FFF7F2CC_100%)]
+    `}
+    >
+      <MainLayout className={`
+        relative z-10 px-5.25 pt-8 pb-16
+        md:px-6 md:pt-14 md:pb-20
+        lg:flex lg:min-h-250 lg:items-center lg:py-0
+      `}
+      >
+        <div className={`
+          grid grid-cols-1 gap-8
+          lg:grid-cols-12 lg:items-center lg:gap-6
+        `}
+        >
+          <div className={`
+            order-2
+            lg:order-1 lg:col-span-6
+          `}
+          >
+            <h2 className={`
+              typo-title-b-1 leading-[1.15] font-bold tracking-[-0.02em]
+              text-gray-900
+            `}
+            >
+              <span className={`
+                block
+                lg:whitespace-nowrap
               `}
               >
                 누구나 거리 위에서
-                <br />
-                공연을 시작할 수 있도록
-              </h2>
-
-              <p className={`
-                mt-6 typo-title-r-4 leading-[1.6] whitespace-nowrap
-                text-gray-700
+              </span>
+              <span className={`
+                block
+                lg:whitespace-nowrap
               `}
               >
-                버스킹이 가능한 장소와 현장을 지도에서 바로 찾아보세요
-              </p>
+                공연을 시작할 수 있도록
+              </span>
+            </h2>
 
-              <form
-                onSubmit={handleSubmit}
-                className="mt-10 w-full max-w-115.75"
+            <p className={`
+              mt-6 typo-title-r-4 leading-[1.6] text-gray-700
+              lg:whitespace-nowrap
+            `}
+            >
+              버스킹이 가능한 장소와 현장을 지도에서 바로 찾아보세요
+            </p>
+
+            <form
+              onSubmit={handleSubmit}
+              className="mt-10 w-full max-w-115.75"
+            >
+              <SearchInput
+                theme="white"
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+                placeholder="지역명이나 장소를 검색해보세요"
+                aria-label="버스킹 장소 검색"
+              />
+            </form>
+          </div>
+
+          <div className={`
+            relative order-1
+            lg:order-2 lg:col-span-6
+          `}
+          >
+            <div className={`
+              relative h-80 w-full overflow-visible
+              sm:h-105
+              md:h-125
+              lg:h-180
+            `}
+            >
+              <Image
+                src={mapBgSrc}
+                alt=""
+                fill
+                priority
+                className="object-contain opacity-50 blur-[2px]"
+              />
+
+              <div className={`
+                absolute inset-0 flex items-center justify-center
+                lg:justify-end
+              `}
               >
-                <SearchInput
-                  theme="white"
-                  value={searchQuery}
-                  onChange={e => setSearchQuery(e.target.value)}
-                  placeholder="지역명이나 장소를 검색해보세요"
-                  aria-label="버스킹 장소 검색"
-                />
-              </form>
-            </div>
-
-            <div className="relative col-span-7">
-              <div className="relative h-180 w-full overflow-visible">
-                <Image
-                  src={mapBgSrc}
-                  alt=""
-                  fill
-                  priority
-                  className="object-contain opacity-50 blur-[2px]"
-                />
-
-                <div className="absolute inset-0 flex items-center justify-end">
-                  <div className="relative h-185 w-265">
-                    <Image
-                      src={heroIllustSrc}
-                      alt="UNIBUSK 지도 일러스트"
-                      fill
-                      priority
-                      className="object-contain"
-                    />
-                  </div>
+                <div className={`
+                  relative h-full w-full
+                  lg:h-185 lg:w-265
+                `}
+                >
+                  <Image
+                    src={heroIllustSrc}
+                    alt="UNIBUSK 지도 일러스트"
+                    fill
+                    priority
+                    className="object-contain"
+                  />
                 </div>
               </div>
             </div>
           </div>
-        </MainLayout>
-      </div>
+        </div>
+      </MainLayout>
     </section>
   );
 }

--- a/src/app/(main)/_components/home-promo-section.tsx
+++ b/src/app/(main)/_components/home-promo-section.tsx
@@ -17,24 +17,36 @@ interface HomePromoSectionProps {
 
 export function HomePromoSection({ ctaHref }: HomePromoSectionProps) {
   return (
-    <section className="w-full bg-white py-20">
-      <MainLayout>
+    <section className={`
+      w-full bg-white py-14
+      md:py-20
+    `}
+    >
+      <MainLayout className={`
+        px-5
+        md:px-6
+      `}
+      >
         <div className="text-center">
           <h2 className="typo-title-sb-2 text-black">공연을 홍보해 보세요</h2>
           <p className="mt-3.75 typo-title-r-4 text-gray-600">나의 공연 정보를 등록하고 홍보해 보세요</p>
         </div>
         <div
           className={cn(
-            'mt-7.5',
+            'mt-12.5',
+            'lg:mt-7.5',
             'w-full rounded-xl',
             'bg-[linear-gradient(90deg,#FFF7ED_0%,#FEF2F2_50%,#FDF2F8F7_100%)]',
-            'px-26 py-18.5',
+            'px-3 py-6',
+            'md:px-10 md:py-12',
+            'lg:px-26 lg:py-18.5',
           )}
         >
 
           <div className={`
-            grid grid-cols-1 gap-6
-            md:grid-cols-2
+            grid grid-cols-2 gap-2.5
+            sm:gap-4
+            md:gap-6
             lg:grid-cols-4
           `}
           >
@@ -44,7 +56,11 @@ export function HomePromoSection({ ctaHref }: HomePromoSectionProps) {
             <PromoStepCard step="Step 4" title="Ready to Go?" description="마지막으로 체크하면 끝!" iconSrc={PROMO_STEP_ICONS.step4} />
           </div>
 
-          <div className="mt-20 flex justify-center">
+          <div className={`
+            mt-10 flex justify-center
+            md:mt-20
+          `}
+          >
             <Button
               asChild
               size="lg"

--- a/src/app/(main)/_components/home-upcoming-busking-section.tsx
+++ b/src/app/(main)/_components/home-upcoming-busking-section.tsx
@@ -14,14 +14,26 @@ export function HomeUpcomingBuskingSection({
   viewAllHref,
 }: HomeUpcomingBuskingSectionProps) {
   return (
-    <section className="w-full bg-white py-20">
-      <MainLayout>
+    <section className={`
+      w-full bg-white py-14
+      md:py-20
+    `}
+    >
+      <MainLayout className={`
+        px-5
+        md:px-6
+      `}
+      >
         <div className="text-center">
           <h2 className="typo-title-sb-2 text-black">{title}</h2>
-          <p className="mt-3.75 typo-title-r-4 text-gray-600">{tags.join(' ')}</p>
+          <p className="mt-3.75 typo-title-r-4 break-keep text-gray-600">{tags.join(' ')}</p>
         </div>
 
-        <div className="mt-14.75 flex justify-end">
+        <div className={`
+          mt-12.5 flex justify-end
+          md:mt-14.75
+        `}
+        >
           <Link
             href={viewAllHref}
             className={`
@@ -33,7 +45,11 @@ export function HomeUpcomingBuskingSection({
           </Link>
         </div>
 
-        <div className="mt-8">
+        <div className={`
+          mt-3
+          md:mt-8
+        `}
+        >
           <UpcomingBuskingCarousel />
         </div>
       </MainLayout>

--- a/src/app/(main)/_components/promo-step-card.tsx
+++ b/src/app/(main)/_components/promo-step-card.tsx
@@ -12,19 +12,35 @@ export function PromoStepCard({ step, title, description, iconSrc }: PromoStepCa
   return (
     <article
       className={cn(
-        'flex flex-col items-center justify-center rounded-2xl bg-white',
-        'h-53 max-w-72.5 px-10 py-6',
+        `
+          mx-auto flex min-h-44 w-full flex-col items-center justify-center
+          rounded-2xl bg-white
+        `,
+        'px-2 py-4',
+        'md:h-53 md:max-w-72.5 md:px-10 md:py-6',
         'shadow-[0_16px_40px_rgba(255,99,71,0.18)]',
       )}
     >
       <div className="flex justify-center">
         <div
           className={`
-            flex h-16 w-16 items-center justify-center rounded-full bg-primary
+            flex h-12 w-12 items-center justify-center rounded-full bg-primary
+            md:h-16 md:w-16
           `}
 
         >
-          <Image src={iconSrc} alt="" className="h-6 w-6" aria-hidden unoptimized width={24} height={24} />
+          <Image
+            src={iconSrc}
+            alt=""
+            className={`
+              h-5 w-5
+              md:h-6 md:w-6
+            `}
+            aria-hidden
+            unoptimized
+            width={24}
+            height={24}
+          />
         </div>
       </div>
 
@@ -32,14 +48,13 @@ export function PromoStepCard({ step, title, description, iconSrc }: PromoStepCa
         {step}
       </div>
       <div className={`
-        mt-2 text-center typo-caption-sb-1 font-semibold whitespace-nowrap
-        text-gray-800
+        mt-2 text-center typo-caption-sb-1 font-semibold text-gray-800
       `}
       >
         {title}
       </div>
       <div className={`
-        mt-2 text-center typo-caption-r-2 whitespace-nowrap text-gray-700
+        mt-2 text-center typo-caption-r-2 break-keep text-gray-700
       `}
       >
         {description}

--- a/src/app/(main)/_components/upcoming-busking-carousel.tsx
+++ b/src/app/(main)/_components/upcoming-busking-carousel.tsx
@@ -56,13 +56,14 @@ export function UpcomingBuskingCarousel() {
 
   return (
     <EmblaCardCarousel
-      perView={4}
+      perView={{ base: 2, md: 3, lg: 4 }}
       slidesToScroll={1}
       gapPx={24}
       showArrows={true}
       showProgress={true}
       progressVariant="thumb"
       className="relative"
+      arrowClassName="hidden lg:flex"
     >
       {items.map((item) => {
         const isSkeleton = Boolean(item.isSkeleton);
@@ -70,15 +71,15 @@ export function UpcomingBuskingCarousel() {
         const isPlaceholder = isSkeleton || !item.imageUrl;
 
         return (
-          <article key={item.id} className="w-full">
+          <article key={item.id} className="h-full w-full">
             <Link
               href={`/performance-detail/${item.id}`}
-              className="group/upcoming-card block"
+              className="group/upcoming-card block h-full"
             >
               <Card
                 className={cn(
                   `
-                    mx-auto h-141 w-85.5 cursor-pointer overflow-hidden
+                    mx-auto h-full w-full cursor-pointer overflow-hidden
                     rounded-xl bg-white transition-all duration-300 ease-in-out
                   `,
                   'shadow-[0_0_10px_0_rgba(0,0,0,0.2)]',
@@ -90,14 +91,15 @@ export function UpcomingBuskingCarousel() {
                 )}
               >
                 <div className={`
-                  relative h-112 w-80.5 overflow-hidden rounded-lg bg-white
+                  relative aspect-[161/224] w-full overflow-hidden rounded-lg
+                  bg-white
                 `}
                 >
                   <Image
                     src={imageSrc}
                     alt=""
                     fill
-                    sizes="322px"
+                    sizes="(min-width: 1024px) 25vw, (min-width: 768px) 33vw, 50vw"
                     unoptimized={true}
                     className={cn(`
                       block transition-transform duration-500

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -36,16 +36,10 @@ export default function HomePage() {
       <JsonLdScript id="website-json-ld" data={getHomeWebsiteJsonLd()} />
       <JsonLdScript id="organization-json-ld" data={getHomeOrganizationJsonLd()} />
       <h1 className="sr-only">UNIBUSK 유니버스크 - 버스킹 공연 일정과 장소 플랫폼</h1>
-      <section className={`
-        min-h-250 w-full
-        bg-[radial-gradient(circle_at_center,#FAFAFA_0%,#FFF7F2CC_100%)]
-      `}
-      >
-        <HomeHeroSection
-          mapBgSrc="/images/main-bg.webp"
-          heroIllustSrc="/images/main-image.webp"
-        />
-      </section>
+      <HomeHeroSection
+        mapBgSrc="/images/main-bg.webp"
+        heroIllustSrc="/images/main-image.webp"
+      />
 
       <HomeUpcomingBuskingSection
         title="다가오는 버스킹"

--- a/src/components/carousel/embla-card-carousel.tsx
+++ b/src/components/carousel/embla-card-carousel.tsx
@@ -10,6 +10,12 @@ function clamp01(value: number) {
 
 type ProgressVariant = 'thumb' | 'fill';
 
+export interface ResponsivePerView {
+  base: number;
+  md?: number;
+  lg?: number;
+}
+
 interface EmblaSnapshot {
   progress: number;
   snapCount: number;
@@ -28,7 +34,7 @@ export interface EmblaCardCarouselProps {
   children: React.ReactNode;
   className?: string;
 
-  perView?: number;
+  perView?: number | ResponsivePerView;
   slidesToScroll?: number;
   loop?: boolean;
 
@@ -53,6 +59,39 @@ function flattenChildren(node: React.ReactNode): React.ReactNode[] {
   }
 
   return [node];
+}
+
+function normalizePerView(value: number) {
+  return Math.max(1, Math.min(value, 12));
+}
+
+function useResponsivePerView(base: number, md: number, lg: number) {
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    const mediaQueries = [
+      window.matchMedia('(min-width: 48rem)'),
+      window.matchMedia('(min-width: 64rem)'),
+    ];
+
+    mediaQueries.forEach(query => query.addEventListener('change', onStoreChange));
+
+    return () => {
+      mediaQueries.forEach(query => query.removeEventListener('change', onStoreChange));
+    };
+  }, []);
+
+  const getSnapshot = useCallback(() => {
+    if (window.matchMedia('(min-width: 64rem)').matches) {
+      return lg;
+    }
+
+    if (window.matchMedia('(min-width: 48rem)').matches) {
+      return md;
+    }
+
+    return base;
+  }, [base, lg, md]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => base);
 }
 
 export function EmblaCardCarousel({
@@ -137,7 +176,10 @@ export function EmblaCardCarousel({
     () => DEFAULT_SNAPSHOT,
   );
 
-  const safePerView = Math.max(1, Math.min(perView, 12));
+  const safePerViewBase = normalizePerView(typeof perView === 'number' ? perView : perView.base);
+  const safePerViewMd = normalizePerView(typeof perView === 'number' ? perView : (perView.md ?? safePerViewBase));
+  const safePerViewLg = normalizePerView(typeof perView === 'number' ? perView : (perView.lg ?? safePerViewMd));
+  const safePerView = useResponsivePerView(safePerViewBase, safePerViewMd, safePerViewLg);
   const hasScrollable = totalSlides > safePerView;
 
   const thumbWidthPct
@@ -174,11 +216,19 @@ export function EmblaCardCarousel({
 
   return (
     <section
-      className={cn('group relative w-full', className)}
+      className={cn(
+        'group relative w-full',
+        '[--carousel-per-view:var(--carousel-per-view-base)]',
+        'md:[--carousel-per-view:var(--carousel-per-view-md)]',
+        'lg:[--carousel-per-view:var(--carousel-per-view-lg)]',
+        className,
+      )}
       style={
         {
-          ['--carousel-gap' as any]: `${gapPx}px`,
-          ['--carousel-per-view' as any]: String(safePerView),
+          '--carousel-gap': `${gapPx}px`,
+          '--carousel-per-view-base': String(safePerViewBase),
+          '--carousel-per-view-md': String(safePerViewMd),
+          '--carousel-per-view-lg': String(safePerViewLg),
         } as React.CSSProperties
       }
     >


### PR DESCRIPTION
## 관련 이슈

<!-- 이슈 번호를 입력하세요. -->

Closes #243 

## 변경사항

<!-- 주요 변경사항을 작성하세요. -->
- 홈 Hero 섹션을 `lg` 미만에서는 모바일 레이아웃, `lg` 이상에서는 데스크톱 레이아웃으로 작업
- Hero 타이틀 `"누구나 거리 위에서"`, `"공연을 시작할 수 있도록"`이 `lg` 이상에서 줄바꿈이 되지 않도록 수정
- 다가오는 버스킹 캐러셀을 `base 2 / md 3 / lg 4` 카드 노출로 변경
- 공연 홍보 섹션은 `lg` 미만에서 `2 x 2`, `lg` 이상에서 `4열` 데스크톱 구조를 사용하도록 조정했습니다.

### ❗ 헤더 작업은 추후 이슈 열어 따로 작업 진행

## 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->
- Hero 섹션이 `lg` 진입 시 모바일 레이아웃에서 데스크톱 레이아웃으로 자연스럽게 전환되는지
- 공연 홍보 섹션이 `lg` 미만에서는 `2 x 2`, `lg` 이상에서는 `4열`로 의도대로 바뀌는지

## 추가 정보

<!-- 스크린샷, 테스트 방법 등 추가 정보가 있다면 작성하세요 -->
<img width="370" height="538" alt="image" src="https://github.com/user-attachments/assets/e78b4f90-da8f-443c-b582-d28258a79153" />

<img width="370" height="538" alt="image" src="https://github.com/user-attachments/assets/584202f4-31d6-46fe-bbfb-5586c13bb368" />
