### PR TITLE
fix: lighthouse job GITHUB_TOKEN 권한 누락으로 PR 코멘트 생성 실패 문제 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     env:
       LHCI_BASE_URL: https://unibusk-preview-${{ github.event.pull_request.number }}.swyp.workers.dev
     steps:


### PR DESCRIPTION
## 관련 이슈
Closes #246

## 변경사항

Lighthouse CI 결과를 PR 코멘트로 게시하기 위한 GITHUB_TOKEN 권한을 추가했습니다.

### 주요 수정
- `lighthouse` job permissions 설정에 `issues: write` 추가
- `github.rest.issues.createComment` API 호출에 필요한 권한 추가

## 리뷰 포인트

- Lighthouse CI 완료 후 PR 코멘트가 정상 생성되는지 확인
- GITHUB_TOKEN 권한 에러가 발생하지 않는지 검증