### PR TITLE
chore: lighthouse CI 실행 전 cloudflare workers warm-up 단계 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,11 +139,12 @@ jobs:
             "$LHCI_BASE_URL/about-us"
           )
           for url in "${URLS[@]}"; do
-            for i in {1..5}; do
-              curl -s -o /dev/null "$url" || true
-            done
+            google-chrome \
+              --headless \
+              --disable-gpu \
+              --no-sandbox \
+              --dump-dom "$url" > /dev/null 2>&1 || true
           done
-          sleep 3
 
       - name: Run Lighthouse CI
         continue-on-error: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,7 +139,7 @@ jobs:
             "$LHCI_BASE_URL/about-us"
           )
           for url in "${URLS[@]}"; do
-            for i in {1..3}; do
+            for i in {1..5}; do
               curl -s -o /dev/null "$url" || true
             done
           done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,12 +139,15 @@ jobs:
             "$LHCI_BASE_URL/about-us"
           )
           for url in "${URLS[@]}"; do
+            echo "Warming up: $url"
             google-chrome \
               --headless \
               --disable-gpu \
               --no-sandbox \
-              --dump-dom "$url" > /dev/null 2>&1 || true
+              --disable-dev-shm-usage \
+              --dump-dom "$url" > /dev/null 2>&1 && echo "✓ Success" || echo "✗ Failed"
           done
+          sleep 5
 
       - name: Run Lighthouse CI
         continue-on-error: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,6 +129,22 @@ jobs:
           done
           echo "preview not ready"; exit 1
 
+      - name: Warm up Cloudflare Workers
+        run: |
+          URLS=(
+            "$LHCI_BASE_URL"
+            "$LHCI_BASE_URL/busking-map"
+            "$LHCI_BASE_URL/performance-list?tab=upcoming"
+            "$LHCI_BASE_URL/performance-list?tab=past"
+            "$LHCI_BASE_URL/about-us"
+          )
+          for url in "${URLS[@]}"; do
+            for i in {1..3}; do
+              curl -s -o /dev/null "$url" || true
+            done
+          done
+          sleep 3
+
       - name: Run Lighthouse CI
         continue-on-error: true
         run: pnpm exec lhci autorun --config=.lighthouserc.ci.js


### PR DESCRIPTION
## 관련 이슈
Closes #248

## 변경사항

Lighthouse CI 측정 전 headless Chrome으로 모든 대상 URL을 warm-up하여 일관된 성능 측정을 보장합니다.

### 주요 작업
- Lighthouse CI 실행 전 headless Chrome warm-up 단계 추가
- curl 방식은 HTML만 fetch하여 CDN 정적 자산 캐시를 채우지 못하는 한계가 있어 headless Chrome으로 교체
- JS·CSS·이미지·폰트 등 전체 자산을 실제 브라우저로 로드하여 CDN 캐시 워밍

## 리뷰 포인트

- Warm-up이 정상 수행되는지 확인
- "/" 라우트의 Lighthouse 점수가 안정적으로 측정되는지 검증
- 모든 대상 URL에서 성능 점수가 실제 운영 환경과 유사하게 측정되는지 확인