### PR TITLE
feat: 로그인 페이지 모바일 뷰 대응 

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -13,47 +13,66 @@ export default function LoginPage() {
   };
 
   return (
+    <div className={`
+      mx-auto mt-40 w-full max-w-62.5
+      sm:mt-[211.5px] sm:max-w-87.5
+    `}
+    >
+      <h1 className={`
+        pb-10 text-center typo-title-b-5
+        sm:pb-[80.5px] sm:typo-title-b-3
+      `}
+      >
+        UNIBUSK 로그인
+      </h1>
 
-    <div className="mt-[211.5px] flex items-center justify-center">
-      <div className="w-87.5 items-center">
-        <h1 className="pb-[80.5px] text-center typo-title-b-3">UNIBUSK 로그인</h1>
+      <div className={`
+        flex w-full items-center justify-center pb-[45px]
+        sm:pb-17.5
+      `}
+      >
+        <Image
+          src="/images/logo_gray.webp"
+          alt="login_logo"
+          width={100}
+          height={90}
+          priority
+          className={`
+            h-20 w-22
+            md:h-22.5 md:w-25
+          `}
+        />
+      </div>
 
-        <div className="flex w-full items-center justify-center pb-17.5">
-          <Image src="/images/logo_gray.webp" alt="login_logo" width={100} height={90} priority />
-        </div>
+      <div className={`
+        flex flex-col space-y-5 text-center typo-body-m-3
+        sm:typo-body-m-1
+      `}
+      >
+        <button
+          type="button"
+          onClick={handleKakaoLogin}
+          className={`
+            flex h-12.5 w-full cursor-pointer items-center justify-center
+            rounded-full bg-kakao p-0 text-black
+            sm:h-15
+          `}
+        >
+          카카오로 로그인 하기
+        </button>
 
-        <div className="flex flex-col space-y-1.25 text-center typo-body-m-1">
-          <button
-            type="button"
-            onClick={handleKakaoLogin}
-            className={`
-              flex h-15 w-full cursor-pointer items-center justify-center
-              rounded-full bg-kakao p-0 text-black
-            `}
-          >
-            카카오로 로그인 하기
-          </button>
-
-          <Link
-            href={routePaths.terms()}
-            className={`
-              inline-flex h-15 items-center justify-center text-gray-400
-              transition-colors
-            `}
-          >
+        <div className={`
+          flex h-15 flex-col justify-center space-y-2.5 typo-caption-m-1
+          text-gray-400
+        `}
+        >
+          <Link href={routePaths.terms()}>
             UNIBUSK 서비스 약관
           </Link>
 
-          <Link
-            href={routePaths.privacy()}
-            className={`
-              inline-flex h-15 items-center justify-center text-gray-400
-              transition-colors
-            `}
-          >
+          <Link href={routePaths.privacy()}>
             UNIBUSK 개인정보 처리방침
           </Link>
-
         </div>
       </div>
     </div>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
-import { ENV, routePaths } from '@/utils';
+import { cn, ENV, routePaths } from '@/utils';
 
 export default function LoginPage() {
   const handleKakaoLogin = () => {
@@ -13,68 +13,80 @@ export default function LoginPage() {
   };
 
   return (
-    <div className={`
-      mx-auto mt-40 w-full max-w-62.5
-      sm:mt-[211.5px] sm:max-w-87.5
-    `}
+    <main className={cn('flex min-h-dvh items-center justify-center', `
+      sm:block sm:min-h-0
+    `)}
     >
-      <h1 className={`
-        pb-10 text-center typo-title-b-5
-        sm:pb-[80.5px] sm:typo-title-b-3
-      `}
+      <div className={cn('mx-auto w-full max-w-62.5', `
+        sm:mt-[211.5px] sm:max-w-87.5
+      `)}
       >
-        UNIBUSK 로그인
-      </h1>
-
-      <div className={`
-        flex w-full items-center justify-center pb-[45px]
-        sm:pb-17.5
-      `}
-      >
-        <Image
-          src="/images/logo_gray.webp"
-          alt="login_logo"
-          width={100}
-          height={90}
-          priority
-          className={`
-            h-20 w-22
-            md:h-22.5 md:w-25
-          `}
-        />
-      </div>
-
-      <div className={`
-        flex flex-col space-y-5 text-center typo-body-m-3
-        sm:typo-body-m-1
-      `}
-      >
-        <button
-          type="button"
-          onClick={handleKakaoLogin}
-          className={`
-            flex h-12.5 w-full cursor-pointer items-center justify-center
-            rounded-full bg-kakao p-0 text-black
-            sm:h-15
-          `}
+        <h1 className={cn('pb-10 text-center typo-title-b-5', `
+          sm:pb-[80.5px] sm:typo-title-b-3
+        `)}
         >
-          카카오로 로그인 하기
-        </button>
+          UNIBUSK 로그인
+        </h1>
 
-        <div className={`
-          flex h-15 flex-col justify-center space-y-2.5 typo-caption-m-1
-          text-gray-400
-        `}
+        <div className={cn('flex w-full items-center justify-center pb-[45px]', `
+          sm:pb-17.5
+        `)}
         >
-          <Link href={routePaths.terms()}>
-            UNIBUSK 서비스 약관
-          </Link>
+          <Image
+            src="/images/logo_gray.webp"
+            alt="login_logo"
+            width={100}
+            height={90}
+            priority
+            className={cn('h-20 w-22', 'md:h-22.5 md:w-25')}
+          />
+        </div>
 
-          <Link href={routePaths.privacy()}>
-            UNIBUSK 개인정보 처리방침
-          </Link>
+        <div className={cn('flex flex-col space-y-5 text-center typo-body-m-3', `
+          sm:typo-body-m-1
+        `)}
+        >
+          <button
+            type="button"
+            onClick={handleKakaoLogin}
+            className={cn(
+              `
+                flex h-12.5 w-full cursor-pointer items-center justify-center
+                rounded-full bg-kakao p-0 text-black
+              `,
+              'sm:h-15',
+            )}
+          >
+            카카오로 로그인 하기
+          </button>
+
+          <div className={cn(`
+            flex h-15 flex-col justify-center space-y-2.5 typo-caption-m-1
+            text-gray-600
+          `)}
+          >
+            <Link
+              href={routePaths.terms()}
+              className={`
+                hover:text-gray-800
+                focus-visible:underline focus-visible:outline-none
+              `}
+            >
+              UNIBUSK 서비스 약관
+            </Link>
+
+            <Link
+              href={routePaths.privacy()}
+              className={`
+                hover:text-gray-800
+                focus-visible:underline focus-visible:outline-none
+              `}
+            >
+              UNIBUSK 개인정보 처리방침
+            </Link>
+          </div>
         </div>
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## 관련 이슈
Closes #222

## 변경사항
- `sm:` breakpoint 기준 모바일/데스크톱 레이아웃 분기
- 고정 너비·마진을 `mx-auto` + `max-w` 반응형으로 교체
- 모바일: `min-h-dvh` + `flex` 수직 중앙 정렬로 기기 높이 대응
- 데스크톱: `sm:block`으로 flex 해제 후 기존 `mt-[211.5px]` 방식 유지
- 타이포그래피·버튼 높이·이미지 크기 모바일 대응
- 링크 대비 개선(`text-gray-400` → `text-gray-600`) 및 hover/focus-visible 상태 추가
- 전체 className 템플릿 리터럴 → `cn()` 통일

## 리뷰 포인트
- `sm:` 단일 breakpoint만 사용한 것으로 충분한지 (태블릿 구간 별도 분기 불필요 여부)
- 링크 접근성 처리 수준 (`focus-visible:underline` + `text-gray-600`)이 충분한지
