### PR TITLE
refactor: 로그인 page.tsx UI를 _components 하위 컴포넌트로 분리

### DIFF
--- a/src/app/(auth)/login/_components/index.ts
+++ b/src/app/(auth)/login/_components/index.ts
@@ -1,0 +1,2 @@
+export { LoginHeader } from './login-header';
+export { LoginKakaoSection } from './login-kakao-section';

--- a/src/app/(auth)/login/_components/login-header.tsx
+++ b/src/app/(auth)/login/_components/login-header.tsx
@@ -1,0 +1,31 @@
+import Image from 'next/image';
+import { cn } from '@/utils';
+
+export function LoginHeader() {
+  return (
+    <>
+      <h1
+        className={cn('pb-10 text-center typo-title-b-5', `
+          sm:pb-[80.5px] sm:typo-title-b-3
+        `)}
+      >
+        UNIBUSK 로그인
+      </h1>
+
+      <div
+        className={cn('flex w-full items-center justify-center pb-[45px]', `
+          sm:pb-17.5
+        `)}
+      >
+        <Image
+          src="/images/logo_gray.webp"
+          alt="login_logo"
+          width={100}
+          height={90}
+          priority
+          className={cn('h-20 w-22', 'md:h-22.5 md:w-25')}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/app/(auth)/login/_components/login-kakao-section.tsx
+++ b/src/app/(auth)/login/_components/login-kakao-section.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import Link from 'next/link';
+import { cn, ENV, routePaths } from '@/utils';
+
+export function LoginKakaoSection() {
+  const handleKakaoLogin = () => {
+    const callbackURL = `${window.location.origin}${routePaths.oauthCallback('kakao')}`;
+    const encodedCallbackUrl = encodeURIComponent(callbackURL);
+
+    window.location.href = `${ENV.NEXT_PUBLIC_API_URL}${routePaths.kakaoLogin()}?state=${encodedCallbackUrl}`;
+  };
+
+  return (
+    <div
+      className={cn('flex flex-col space-y-5 text-center typo-body-m-3', `
+        sm:typo-body-m-1
+      `)}
+    >
+      <button
+        type="button"
+        onClick={handleKakaoLogin}
+        className={cn(
+          `
+            flex h-12.5 w-full cursor-pointer items-center justify-center
+            rounded-full bg-kakao p-0 text-black
+          `,
+          'sm:h-15',
+        )}
+      >
+        카카오로 로그인 하기
+      </button>
+
+      <div
+        className={cn(`
+          flex h-15 flex-col justify-center space-y-2.5 typo-caption-m-1
+          text-gray-600
+        `)}
+      >
+        <Link
+          href={routePaths.terms()}
+          className={`
+            hover:text-gray-800
+            focus-visible:underline focus-visible:outline-none
+          `}
+        >
+          UNIBUSK 서비스 약관
+        </Link>
+
+        <Link
+          href={routePaths.privacy()}
+          className={`
+            hover:text-gray-800
+            focus-visible:underline focus-visible:outline-none
+          `}
+        >
+          UNIBUSK 개인정보 처리방침
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,91 +1,21 @@
-'use client';
+import { cn } from '@/utils';
 
-import Image from 'next/image';
-import Link from 'next/link';
-import { cn, ENV, routePaths } from '@/utils';
+import { LoginHeader, LoginKakaoSection } from './_components';
 
 export default function LoginPage() {
-  const handleKakaoLogin = () => {
-    const callbackURL = `${window.location.origin}${routePaths.oauthCallback('kakao')}`;
-    const encodedCallbackUrl = encodeURIComponent(callbackURL);
-
-    window.location.href = `${ENV.NEXT_PUBLIC_API_URL}${routePaths.kakaoLogin()}?state=${encodedCallbackUrl}`;
-  };
-
   return (
-    <main className={cn('flex min-h-dvh items-center justify-center', `
-      sm:block sm:min-h-0
-    `)}
-    >
-      <div className={cn('mx-auto w-full max-w-62.5', `
-        sm:mt-[211.5px] sm:max-w-87.5
+    <main
+      className={cn('flex min-h-dvh items-center justify-center', `
+        sm:block sm:min-h-0
       `)}
+    >
+      <div
+        className={cn('mx-auto w-full max-w-62.5', `
+          sm:mt-[211.5px] sm:max-w-87.5
+        `)}
       >
-        <h1 className={cn('pb-10 text-center typo-title-b-5', `
-          sm:pb-[80.5px] sm:typo-title-b-3
-        `)}
-        >
-          UNIBUSK 로그인
-        </h1>
-
-        <div className={cn('flex w-full items-center justify-center pb-[45px]', `
-          sm:pb-17.5
-        `)}
-        >
-          <Image
-            src="/images/logo_gray.webp"
-            alt="login_logo"
-            width={100}
-            height={90}
-            priority
-            className={cn('h-20 w-22', 'md:h-22.5 md:w-25')}
-          />
-        </div>
-
-        <div className={cn('flex flex-col space-y-5 text-center typo-body-m-3', `
-          sm:typo-body-m-1
-        `)}
-        >
-          <button
-            type="button"
-            onClick={handleKakaoLogin}
-            className={cn(
-              `
-                flex h-12.5 w-full cursor-pointer items-center justify-center
-                rounded-full bg-kakao p-0 text-black
-              `,
-              'sm:h-15',
-            )}
-          >
-            카카오로 로그인 하기
-          </button>
-
-          <div className={cn(`
-            flex h-15 flex-col justify-center space-y-2.5 typo-caption-m-1
-            text-gray-600
-          `)}
-          >
-            <Link
-              href={routePaths.terms()}
-              className={`
-                hover:text-gray-800
-                focus-visible:underline focus-visible:outline-none
-              `}
-            >
-              UNIBUSK 서비스 약관
-            </Link>
-
-            <Link
-              href={routePaths.privacy()}
-              className={`
-                hover:text-gray-800
-                focus-visible:underline focus-visible:outline-none
-              `}
-            >
-              UNIBUSK 개인정보 처리방침
-            </Link>
-          </div>
-        </div>
+        <LoginHeader />
+        <LoginKakaoSection />
       </div>
     </main>
   );


### PR DESCRIPTION
## 관련 이슈
Closes #254

## 변경사항
- `login/_components/login-header.tsx` — 타이틀·로고를 Server Component로 분리
- `login/_components/login-kakao-section.tsx` — 카카오 로그인 버튼·약관 링크를 Client Component로 분리
- `page.tsx` — `'use client'` 제거, 두 컴포넌트 조립 역할만 담당

## 리뷰 포인트
- `login-header.tsx`는 `'use client'` 없이 서버 렌더링 가능한 정적 UI만 포함했는지 (`Image`, `h1`)
