### PR TITLE
refactor: 공연 프리뷰 DTO 스키마 중복 제거

### DIFF
--- a/src/apis/performance/performance.schema.ts
+++ b/src/apis/performance/performance.schema.ts
@@ -73,6 +73,19 @@ export const PerformanceCreateRequestDtoSchema = z.object({
   ]).optional(),
 });
 
+export const PerformancePreviewItemDtoSchema = z.object({
+  performanceId: z.number(),
+  title: z.string(),
+  performanceDate: z.string().regex(
+    /^\d{4}-\d{2}-\d{2}$/,
+    'Invalid date format: expected YYYY-MM-DD',
+  ),
+  startTime: transformerISOToHHmmSchema,
+  endTime: transformerISOToHHmmSchema,
+  locationName: z.string(),
+  images: z.array(z.string()).default([]),
+});
+
 /**
  * 공연 리스트 조회 API 응답 스키마
  *
@@ -81,25 +94,7 @@ export const PerformanceCreateRequestDtoSchema = z.object({
  */
 export const PerformanceListResponseDtoSchema = z.object({
   /** 공연 목록 배열 */
-  content: z.array(z.object({
-    /** 공연 고유 ID */
-    performanceId: z.number(),
-    /** 공연 제목 */
-    title: z.string(),
-    /** 공연 날짜 (YYYY-MM-DD 형식) */
-    performanceDate: z.string().regex(
-      /^\d{4}-\d{2}-\d{2}$/,
-      'Invalid date format: expected YYYY-MM-DD',
-    ),
-    /** 공연 시작 시간 (ISO 형식 → HH:mm 형식으로 변환) */
-    startTime: transformerISOToHHmmSchema,
-    /** 공연 종료 시간 (ISO 형식 → HH:mm 형식으로 변환) */
-    endTime: transformerISOToHHmmSchema,
-    /** 공연 장소명 */
-    locationName: z.string(),
-    /** 공연 이미지 URL 배열 */
-    images: z.array(z.string()).default([]),
-  })),
+  content: z.array(PerformancePreviewItemDtoSchema),
   /** 현재 페이지 번호 (0부터 시작) */
   page: z.int().nonnegative(),
   /** 페이지당 항목 수 */
@@ -165,6 +160,9 @@ export type PerformanceListResponseDto = z.infer<typeof PerformanceListResponseD
 /** 공연 상세 조회 API 응답 타입 */
 export type PerformanceDetailResponseDto = z.infer<typeof PerformanceDetailResponseDtoSchema>;
 
+/** 공연 목록·홈 프리뷰 공통 아이템 타입 */
+export type PerformancePreviewItemDto = z.infer<typeof PerformancePreviewItemDtoSchema>;
+
 // 공연 장소별 공연 리스트 아이템(카드 1개)
 export const performanceByLocationItemSchema = z.object({
   performanceId: z.number(),
@@ -187,15 +185,7 @@ export type PerformanceByLocationItem = z.infer<typeof performanceByLocationItem
 export type PerformanceByLocationCursorResponse = z.infer<typeof performanceByLocationCursorSchema>;
 
 // home: 다가오는 공연 8개
-export const PerformanceUpcomingPreviewItemDtoSchema = z.object({
-  performanceId: z.number(),
-  title: z.string(),
-  performanceDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  startTime: transformerISOToHHmmSchema,
-  endTime: transformerISOToHHmmSchema,
-  locationName: z.string(),
-  images: z.array(z.string()).default([]),
-});
+export const PerformanceUpcomingPreviewItemDtoSchema = PerformancePreviewItemDtoSchema;
 
 export const PerformanceUpcomingPreviewResponseDtoSchema = z.array(
   PerformanceUpcomingPreviewItemDtoSchema,

--- a/src/app/(main)/_components/upcoming-busking-carousel.tsx
+++ b/src/app/(main)/_components/upcoming-busking-carousel.tsx
@@ -25,10 +25,7 @@ function formatDateText(performanceDate: string, startTime: string, endTime: str
   const mm = m ?? '00';
   const dd = d ?? '00';
 
-  const start = startTime.length >= 16 ? startTime.slice(11, 16) : startTime;
-  const end = endTime.length >= 16 ? endTime.slice(11, 16) : endTime;
-
-  return `${yyyy}.${mm}.${dd} (${start}~${end})`;
+  return `${yyyy}.${mm}.${dd} (${startTime}~${endTime})`;
 }
 
 function mapDtoToItem(dto: PerformanceUpcomingPreviewItemDto): UpcomingItem {


### PR DESCRIPTION
## 관련 이슈
Closes #257

## 변경사항
- `PerformancePreviewItemDtoSchema` 공통 스키마 추출
- `PerformanceListResponseDtoSchema` content와 `PerformanceUpcomingPreviewItemDtoSchema`에 적용
- `formatDateText`의 ISO 시간 파싱 방어 코드 제거 (스키마 레이어에서 이미 HH:mm 변환)

## 리뷰 포인트
- `PerformanceUpcomingPreviewItemDtoSchema`를 삭제하지 않고 alias로 유지한 방식이 적절한지 (기존 import 사용처 보존 vs 명시적 제거 후 일괄 교체)
- `PerformancePreviewItemDtoSchema`가 `index.ts`에 export되지 않는데, 외부 사용 가능성을 고려해 공개 API로 열어야 하는지
- `formatDateText` ISO 방어 코드 제거 범위가 충분한지 — `?? '0000'` 등 date split fallback도 Zod 스키마가 보장하므로 제거 대상에 해당하는지
