### PR TITLE
feat: 공연 카드 스켈레톤 추가 및 카드 UI 통합

### DIFF
--- a/src/app/(main)/_components/upcoming-busking-carousel.tsx
+++ b/src/app/(main)/_components/upcoming-busking-carousel.tsx
@@ -1,55 +1,12 @@
 'use client';
 
-import type { PerformanceUpcomingPreviewItemDto } from '@/apis/performance';
-import Image from 'next/image';
-import Link from 'next/link';
 import { EmblaCardCarousel } from '@/components/carousel';
-import { Card } from '@/components/common/card';
+import { PerformanceCard, PerformanceCardSkeleton } from '@/components/performance';
 import { useUpcomingPerformancePreview } from '@/hooks/performance/use-upcoming-performance-preview';
-import { cn } from '@/utils';
-
-interface UpcomingItem {
-  id: string;
-  dateText: string;
-  placeText: string;
-  title: string;
-  imageUrl: string | null;
-  isSkeleton?: boolean;
-}
-
-const SKELETON_IMAGE_SRC = '/images/loading-unibusk-vertical.png';
-
-function formatDateText(performanceDate: string, startTime: string, endTime: string) {
-  const [y, m, d] = performanceDate.split('-');
-  const yyyy = y ?? '0000';
-  const mm = m ?? '00';
-  const dd = d ?? '00';
-
-  return `${yyyy}.${mm}.${dd} (${startTime}~${endTime})`;
-}
-
-function mapDtoToItem(dto: PerformanceUpcomingPreviewItemDto): UpcomingItem {
-  return {
-    id: String(dto.performanceId),
-    dateText: formatDateText(dto.performanceDate, dto.startTime, dto.endTime),
-    placeText: dto.locationName,
-    title: dto.title,
-    imageUrl: dto.images?.[0] ?? null,
-  };
-}
+import { routePaths } from '@/utils';
 
 export function UpcomingBuskingCarousel() {
-  const skeleton: UpcomingItem[] = Array.from({ length: 8 }, (_, i) => ({
-    id: `skeleton-${i + 1}`,
-    dateText: ' ',
-    placeText: ' ',
-    title: ' ',
-    imageUrl: null,
-    isSkeleton: true,
-  }));
-
   const { data, isPending } = useUpcomingPerformancePreview();
-  const items = isPending ? skeleton : (data ?? []).map(mapDtoToItem);
 
   return (
     <EmblaCardCarousel
@@ -62,90 +19,15 @@ export function UpcomingBuskingCarousel() {
       className="relative"
       arrowClassName="hidden lg:flex"
     >
-      {items.map((item) => {
-        const isSkeleton = Boolean(item.isSkeleton);
-        const imageSrc = item.imageUrl ?? SKELETON_IMAGE_SRC;
-        const isPlaceholder = isSkeleton || !item.imageUrl;
-
-        return (
-          <article key={item.id} className="h-full w-full">
-            <Link
-              href={`/performance-detail/${item.id}`}
-              className="group/upcoming-card block h-full"
-              aria-label={isSkeleton ? undefined : `${item.title} 공연 상세 보기`}
-            >
-              <Card
-                className={cn(
-                  `
-                    mx-auto h-full w-full cursor-pointer overflow-hidden
-                    rounded-xl bg-white transition-all duration-300 ease-in-out
-                  `,
-                  'shadow-[0_0_10px_0_rgba(0,0,0,0.2)]',
-                  'p-2.5',
-                  'gap-0 border border-transparent py-0 text-black shadow-none',
-                  'hover:border-border/30',
-                  'hover:shadow-lg',
-                  'active:scale-[0.98]',
-                )}
-              >
-                <div className={`
-                  relative aspect-[161/224] w-full overflow-hidden rounded-lg
-                  bg-white
-                `}
-                >
-                  <Image
-                    src={imageSrc}
-                    alt=""
-                    fill
-                    sizes="(min-width: 1024px) 25vw, (min-width: 768px) 33vw, 50vw"
-                    unoptimized={true}
-                    className={cn(`
-                      block transition-transform duration-500
-                      group-hover/upcoming-card:scale-105
-                    `, isPlaceholder
-                      ? 'object-contain'
-                      : `object-cover`)}
-                  />
-                  <div
-                    className={`
-                      absolute inset-0 z-0 bg-linear-to-t from-black/20
-                      via-transparent to-transparent opacity-0
-                      transition-opacity duration-300
-                      group-hover/upcoming-card:opacity-100
-                    `}
-                  />
-                </div>
-
-                <div className="p-2.5">
-                  <div className={cn(`
-                    mt-0.75 typo-caption-r-1 text-gray-700 transition-colors
-                    duration-200
-                  `, isSkeleton && `opacity-0`)}
-                  >
-                    {item.dateText}
-                  </div>
-
-                  <div className={cn(`
-                    mt-0.5 flex gap-1.75 typo-caption-r-1 text-gray-700
-                  `, isSkeleton && `opacity-0`)}
-                  >
-                    <Image src="/icons/mapPin.svg" width={11} height={14.37} alt="" unoptimized />
-                    {item.placeText}
-                  </div>
-
-                  <div className={cn(`
-                    mt-0.75 typo-body-sb-2 text-black
-                    group-hover/upcoming-card:text-primary
-                  `, isSkeleton && `opacity-0`)}
-                  >
-                    {item.title}
-                  </div>
-                </div>
-              </Card>
-            </Link>
-          </article>
-        );
-      })}
+      {isPending
+        ? Array.from({ length: 8 }, (_, i) => <PerformanceCardSkeleton key={i} />)
+        : (data ?? []).map(dto => (
+            <PerformanceCard
+              key={dto.performanceId}
+              performance={dto}
+              href={routePaths.performanceDetail(dto.performanceId)}
+            />
+          ))}
     </EmblaCardCarousel>
   );
 }

--- a/src/app/(main)/performance-list/_components/performance-list.tsx
+++ b/src/app/(main)/performance-list/_components/performance-list.tsx
@@ -3,7 +3,7 @@
 import type { Performances } from '@/types/performance';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useRef } from 'react';
-import { PerformanceCard } from '@/components/performance';
+import { PerformanceCard, PerformanceCardSkeleton } from '@/components/performance';
 import { routePaths } from '@/utils';
 
 interface PerformanceListProps {
@@ -65,14 +65,15 @@ export function PerformanceList({
       `}
       >
         {performanceCards}
+        {isLoading && (
+          <>
+            <PerformanceCardSkeleton className="w-full" />
+            <PerformanceCardSkeleton className="w-full" />
+          </>
+        )}
       </div>
       {hasMore && (
-        <div
-          ref={observerTarget}
-          className="flex h-20 items-center justify-center"
-        >
-          {isLoading && <div>로딩 중...</div>}
-        </div>
+        <div ref={observerTarget} className="h-4" />
       )}
     </div>
   );

--- a/src/app/(main)/performance-list/_components/performance-list.tsx
+++ b/src/app/(main)/performance-list/_components/performance-list.tsx
@@ -65,12 +65,9 @@ export function PerformanceList({
       `}
       >
         {performanceCards}
-        {isLoading && (
-          <>
-            <PerformanceCardSkeleton className="w-full" />
-            <PerformanceCardSkeleton className="w-full" />
-          </>
-        )}
+        {isLoading && Array.from({ length: 12 }, (_, i) => (
+          <PerformanceCardSkeleton key={i} className="w-full" />
+        ))}
       </div>
       {hasMore && (
         <div ref={observerTarget} className="h-4" />

--- a/src/app/(main)/performance-list/page.tsx
+++ b/src/app/(main)/performance-list/page.tsx
@@ -1,6 +1,7 @@
 import type { PerformanceFilterTab } from '@/types/performance';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import { Suspense } from 'react';
+import { PerformanceCardSkeleton } from '@/components/performance';
 import { getQueryClient } from '@/queries';
 import { performanceListInfiniteQueryOptions } from '@/queries/performance';
 import { isValidPerformanceTab } from '@/types/performance';
@@ -38,7 +39,21 @@ export default async function PerformanceListPage({ searchParams }: PageProps) {
 
         <Hero />
         <HydrationBoundary state={dehydrate(queryClient)}>
-          <Suspense fallback={<div>로딩 중...</div>}>
+          <Suspense
+            fallback={(
+              <div className={`
+                grid w-full grid-cols-1 gap-6 px-4 pt-8
+                sm:grid-cols-2
+                lg:grid-cols-3
+                xl:grid-cols-4
+              `}
+              >
+                {Array.from({ length: 8 }, (_, i) => (
+                  <PerformanceCardSkeleton key={i} className="w-full" />
+                ))}
+              </div>
+            )}
+          >
             <PerformanceTabs
               defaultTab={tab}
             />

--- a/src/components/performance/index.ts
+++ b/src/components/performance/index.ts
@@ -1,4 +1,4 @@
-export { PerformanceCard } from './performance-card';
+export { PerformanceCard, PerformanceCardSkeleton } from './performance-card';
 export { PerformanceDeleteConfirmDialog } from './performance-delete-confirm-dialog';
 export { PerformanceRegisterButton } from './performance-register-button';
 export { RegisterModal } from './register-modal';

--- a/src/components/performance/performance-card/index.ts
+++ b/src/components/performance/performance-card/index.ts
@@ -1,1 +1,2 @@
 export { PerformanceCard } from './performance-card';
+export { PerformanceCardSkeleton } from './performance-card-skeleton';

--- a/src/components/performance/performance-card/performance-card-skeleton.tsx
+++ b/src/components/performance/performance-card/performance-card-skeleton.tsx
@@ -1,0 +1,35 @@
+import { Card, CardContent } from '@/components/common/card';
+import { Skeleton } from '@/components/common/skeleton';
+import { cn } from '@/utils';
+
+interface PerformanceCardSkeletonProps {
+  className?: string;
+}
+
+export function PerformanceCardSkeleton({ className }: PerformanceCardSkeletonProps) {
+  return (
+    <Card
+      className={cn(
+        `
+          h-full w-full overflow-hidden border-transparent bg-transparent py-0
+          shadow-none
+        `,
+        className,
+      )}
+    >
+      <CardContent className="flex h-full flex-col p-2.5">
+        <Skeleton className="aspect-5/8 w-full shrink-0 rounded-lg" />
+        <div className={`
+          flex flex-1 flex-col gap-1.5 p-1.5
+          sm:p-2.5
+        `}
+        >
+          <Skeleton className="h-3.5 w-3/4 rounded" />
+          <Skeleton className="h-3.5 w-1/2 rounded" />
+          <Skeleton className="mt-0.75 h-4 w-full rounded" />
+          <Skeleton className="h-4 w-4/5 rounded" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/performance/performance-card/performance-card.tsx
+++ b/src/components/performance/performance-card/performance-card.tsx
@@ -19,6 +19,7 @@ export const PerformanceCard = memo(({ performance, href, className }: Performan
   const { title, performanceDate, startTime, endTime, locationName, images } = performance;
 
   const showPlaceholder = !images[0] || imageError;
+  const formattedDate = performanceDate.replaceAll('-', '.');
 
   return (
     <Link href={href} className="group block h-full">
@@ -91,7 +92,7 @@ export const PerformanceCard = memo(({ performance, href, className }: Performan
           >
             <div className="shrink-0">
               <p className="tabular-nums">
-                {`${performanceDate} (${startTime}~${endTime})`}
+                {`${formattedDate} (${startTime}~${endTime})`}
               </p>
 
               <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## 관련 이슈
Closes #258 

## 변경사항
- `PerformanceCardSkeleton` 컴포넌트 추가 (PerformanceCard 레이아웃 기반 skeleton)
- `UpcomingBuskingCarousel` 인라인 카드 UI(143줄) → `PerformanceCard` + `PerformanceCardSkeleton` 교체
- `performance-list` Suspense fallback 및 더보기 로딩 텍스트 → 스켈레톤 카드로 교체
- `PerformanceCard` 날짜 포맷 통일 (YYYY-MM-DD → YYYY.MM.DD)

## 리뷰 포인트
- `PerformanceCardSkeleton`이 실제 카드와 높이, 간격, 반응형 레이아웃을 자연스럽게 맞추는지 확인해 주세요.
- 무한 스크롤 observer 영역을 `h-20`에서 `h-4`로 줄인 변경이 더보기 트리거 시점에 영향을 주지 않는지 확인해 주세요.
