### PR TITLE
feat: 다가오는 공연/지난 공연 모바일 뷰 레이아웃 대응

### DIFF
--- a/src/app/(main)/performance-list/_components/hero.tsx
+++ b/src/app/(main)/performance-list/_components/hero.tsx
@@ -8,9 +8,9 @@ export function Hero() {
   return (
     <section
       className={cn(`
-        relative flex h-85 w-full justify-start overflow-hidden rounded-lg
+        relative flex h-28.5 w-full justify-start overflow-hidden rounded-lg
+        sm:h-60
         md:h-115
-        xl:h-122.75
       `)}
       aria-label="공연 등록 안내"
     >
@@ -19,23 +19,36 @@ export function Hero() {
         alt="공연 등록 가이드 HERO 일러스트"
         fill
         className={cn(`
-          rounded-lg object-contain object-right
-          md:object-center
+          rounded-none object-cover object-right
+          sm:rounded-lg sm:object-contain sm:object-center
         `)}
         priority
       />
 
       <div className={cn(`
-        relative z-10 mt-auto flex flex-col space-y-6 pb-8 pl-5
-        md:space-y-8 md:pb-16 md:pl-10
-        xl:space-y-14.75 xl:pb-40.5 xl:pl-27.25
+        relative z-10 mt-auto flex flex-col space-y-2 pb-4 pl-5
+        sm:space-y-4 sm:pb-15 sm:pl-12.5
+        md:space-y-8 md:pb-40.5 md:pl-27.5
       `)}
       >
-        <h2 className="typo-title-sb-2 text-black">
+        <h2 className={`
+          typo-caption-sb-1 text-black
+          md:typo-title-sb-2
+        `}
+        >
           <span className="block">나의 공연 정보를</span>
           <span className="block">등록하고 홍보해 보세요</span>
         </h2>
-        <PerformanceRegisterButton theme="orange" size="lg" appearance="filled">
+        <PerformanceRegisterButton
+          theme="orange"
+          size="lg"
+          mobileSize="xs"
+          appearance="filled"
+          className={`
+            sm:h-9 sm:min-w-30 sm:typo-caption-r-2
+            md:h-15 md:min-w-87.5 md:typo-body-sb-1
+          `}
+        >
           공연 등록하기
         </PerformanceRegisterButton>
       </div>

--- a/src/app/(main)/performance-list/_components/performance-list.tsx
+++ b/src/app/(main)/performance-list/_components/performance-list.tsx
@@ -58,8 +58,8 @@ export function PerformanceList({
   return (
     <div>
       <div className={`
-        grid w-full grid-cols-1 gap-6
-        sm:grid-cols-2
+        grid w-full grid-cols-2 gap-3
+        sm:gap-6
         lg:grid-cols-3
         xl:grid-cols-4
       `}

--- a/src/app/(main)/performance-list/_components/performance-search.tsx
+++ b/src/app/(main)/performance-list/_components/performance-search.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { SearchInput } from '@/components/common/search-input';
+import { cn } from '@/utils';
 
 interface PerformanceSearchProps {
   /** 검색 실행 핸들러 */
@@ -36,11 +37,7 @@ export function PerformanceSearch({ onSearch }: PerformanceSearchProps) {
   };
 
   return (
-    <div className={`
-      relative w-full
-      md:w-auto md:min-w-115.75
-    `}
-    >
+    <div className={cn('relative w-full', 'md:w-auto md:min-w-115.75')}>
       <SearchInput
         value={inputValue}
         onChange={handleChange}

--- a/src/app/(main)/performance-list/_components/performance-search.tsx
+++ b/src/app/(main)/performance-list/_components/performance-search.tsx
@@ -36,7 +36,11 @@ export function PerformanceSearch({ onSearch }: PerformanceSearchProps) {
   };
 
   return (
-    <div className="relative min-w-115.75">
+    <div className={`
+      relative w-full
+      md:w-auto md:min-w-115.75
+    `}
+    >
       <SearchInput
         value={inputValue}
         onChange={handleChange}

--- a/src/app/(main)/performance-list/_components/performance-tabs.tsx
+++ b/src/app/(main)/performance-list/_components/performance-tabs.tsx
@@ -17,7 +17,10 @@ interface PerformanceTabsProps {
 
 const TAB_TRIGGER_STYLES = cn(
   'rounded-none border-b-2 border-transparent px-0 py-5.25',
-  'cursor-pointer typo-title-b-3 text-gray-300',
+  `
+    cursor-pointer typo-body-sb-2 text-gray-300
+    md:typo-title-b-3
+  `,
   'hover:text-gray-400',
   'data-[state=active]:border-b-primary data-[state=active]:text-primary',
   'data-[state=active]:bg-transparent data-[state=active]:shadow-none',
@@ -59,11 +62,15 @@ export function PerformanceTabs({
         onValueChange={handleTabChange}
       >
         <div className={`
-          flex w-full items-center justify-between border-b-2 border-gray-300
+          flex w-full flex-col gap-7.5
+          md:flex-row md:items-center md:justify-between md:gap-0 md:border-b-2
+          md:border-gray-300
         `}
         >
           <TabsList className={cn(`
-            h-auto w-auto translate-y-0.5 gap-6 bg-transparent p-0 text-gray-300
+            h-auto w-auto translate-y-0.5 gap-6 rounded-none border-b-2
+            border-gray-300 bg-transparent p-0 text-gray-300
+            md:border-none
           `)}
           >
             <TabsTrigger
@@ -84,7 +91,13 @@ export function PerformanceTabs({
         </div>
 
         <div className="w-full justify-between">
-          <p className="py-20 text-center typo-body-sb-2 text-black">지금 준비중인 소규모 공연을 만나보세요</p>
+          <p className={`
+            pt-10 pb-7.5 text-center typo-caption-m-1 text-black
+            md:py-20 md:typo-body-sb-2
+          `}
+          >
+            지금 준비중인 소규모 공연을 만나보세요
+          </p>
 
           <TabsContent value="upcoming">
             <Suspense fallback={<output className="flex justify-center py-20">로딩 중...</output>}>

--- a/src/app/(main)/performance-list/_components/performance-tabs.tsx
+++ b/src/app/(main)/performance-list/_components/performance-tabs.tsx
@@ -61,11 +61,10 @@ export function PerformanceTabs({
         value={validTab}
         onValueChange={handleTabChange}
       >
-        <div className={`
-          flex w-full flex-col gap-7.5
+        <div className={cn('flex w-full flex-col gap-7.5', `
           md:flex-row md:items-center md:justify-between md:gap-0 md:border-b-2
           md:border-gray-300
-        `}
+        `)}
         >
           <TabsList className={cn(`
             h-auto w-auto translate-y-0.5 gap-6 rounded-none border-b-2
@@ -91,10 +90,9 @@ export function PerformanceTabs({
         </div>
 
         <div className="w-full justify-between">
-          <p className={`
+          <p className={cn(`
             pt-10 pb-7.5 text-center typo-caption-m-1 text-black
-            md:py-20 md:typo-body-sb-2
-          `}
+          `, `md:py-20 md:typo-body-sb-2`)}
           >
             지금 준비중인 소규모 공연을 만나보세요
           </p>

--- a/src/app/(main)/performance-list/page.tsx
+++ b/src/app/(main)/performance-list/page.tsx
@@ -42,8 +42,8 @@ export default async function PerformanceListPage({ searchParams }: PageProps) {
           <Suspense
             fallback={(
               <div className={`
-                grid w-full grid-cols-1 gap-6 px-4 pt-8
-                sm:grid-cols-2
+                grid w-full grid-cols-2 gap-3 px-4 pt-8
+                sm:gap-6
                 lg:grid-cols-3
                 xl:grid-cols-4
               `}


### PR DESCRIPTION
## 관련 이슈
Closes #262

## 변경사항
- 공연 목록을 모바일 화면에서 2열 카드 레이아웃으로 변경했습니다.
- hero 영역과 공연 등록 버튼의 반응형 스타일을 조정했습니다.
- 탭, 검색창, 안내 문구를 모바일 화면에 맞게 배치했습니다.
- 로딩 fallback에도 동일한 2열 레이아웃을 적용했습니다.

## 리뷰 포인트
- 모바일부터 데스크톱까지 breakpoint별 레이아웃 전환이 자연스러운지 확인해 주세요.
- 실제 목록과 로딩 fallback의 카드 배치가 일관적인지 확인해 주세요.