### PR TITLE
fix: 변경된 공연 이미지 응답 스키마 반영 (images → imageUrl)

### DIFF
--- a/src/apis/performance/performance.schema.ts
+++ b/src/apis/performance/performance.schema.ts
@@ -83,7 +83,7 @@ export const PerformancePreviewItemDtoSchema = z.object({
   startTime: transformerISOToHHmmSchema,
   endTime: transformerISOToHHmmSchema,
   locationName: z.string(),
-  images: z.array(z.string()).default([]),
+  imageUrl: z.string().nullish(),
 });
 
 /**
@@ -128,7 +128,7 @@ export const PerformanceDetailResponseDtoSchema = z.object({
   /** 공연 상세 설명 */
   description: z.string(),
   /** 공연 이미지 URL 목록 */
-  images: z.array(z.string()).default([]),
+  imageUrl: z.string().nullish(),
   /** 공연자 정보 목록 */
   performers: z.array(z.object({
     /** 공연자 이름 */
@@ -170,7 +170,7 @@ export const performanceByLocationItemSchema = z.object({
   performanceDate: z.string(),
   startTime: z.string(),
   endTime: z.string(),
-  images: z.array(z.string()),
+  imageUrl: z.string().nullish(),
 });
 
 // cursor 기반 리스트 응답
@@ -207,7 +207,7 @@ export const MyPerformanceSummarySchema = z.object({
   startTime: z.string(), // ISO 8601 그대로 유지 (date-fns format 사용)
   endTime: z.string(),
   performanceLocationName: z.string(),
-  imageUrls: z.array(z.string()).default([]),
+  imageUrl: z.string().nullish(),
 });
 
 // 내 공연 목록 커서 응답 스키마

--- a/src/app/(main)/performance-detail/[performanceId]/_components/performance-info.tsx
+++ b/src/app/(main)/performance-detail/[performanceId]/_components/performance-info.tsx
@@ -32,7 +32,7 @@ interface PerformanceInfoProps {
 
 export function PerformanceInfo({ performanceId }: PerformanceInfoProps) {
   const { data: performanceDetail } = useSuspenseQuery(performanceDetailQueryOptions(performanceId));
-  const { title, performanceDate, locationName, images, summary, startTime, endTime, performers, description, latitude, longitude, memberId } = performanceDetail;
+  const { title, performanceDate, locationName, imageUrl, summary, startTime, endTime, performers, description, latitude, longitude, memberId } = performanceDetail;
   const router = useRouter();
   const { user, isAuthenticated, isPending } = useAuth();
   const isOwner = !isPending && isAuthenticated && user?.memberId === memberId;
@@ -50,7 +50,7 @@ export function PerformanceInfo({ performanceId }: PerformanceInfoProps) {
       </Suspense>
       <Content
         title={title}
-        posterUrl={images[0]}
+        posterUrl={imageUrl}
         summary={summary}
         startTime={startTime}
         endTime={endTime}
@@ -224,7 +224,7 @@ function PerformanceOwnerMenu({ performanceId }: PerformanceOwnerMenuProps) {
 
 interface ContentProps {
   title: string;
-  posterUrl: string;
+  posterUrl: string | null | undefined;
   summary: string;
   startTime: string;
   endTime: string;

--- a/src/app/(main)/performance-detail/[performanceId]/page.tsx
+++ b/src/app/(main)/performance-detail/[performanceId]/page.tsx
@@ -39,7 +39,7 @@ export async function generateMetadata(
     title: performanceDetail.title,
     description: `${performanceDetail.title} 공연의 일정, 장소, 상세 정보를 확인해보세요.`,
     path: `/performance-detail/${performanceId}`,
-    image: performanceDetail.images[0],
+    image: performanceDetail.imageUrl ?? undefined,
   });
 }
 

--- a/src/app/(main)/profile/_components/profile-performances.tsx
+++ b/src/app/(main)/profile/_components/profile-performances.tsx
@@ -27,7 +27,7 @@ interface MyPerformanceCardProps {
   startTime: string;
   endTime: string;
   performanceLocationName: string;
-  imageUrls: string[];
+  imageUrl?: string | null;
 }
 
 interface MyPerformanceCardMoreMenuProps {
@@ -108,7 +108,7 @@ function Performances({ performances, onLoadMore, hasMore, isLoading }: Performa
           startTime={performance.startTime}
           endTime={performance.endTime}
           performanceLocationName={performance.performanceLocationName}
-          imageUrls={performance.imageUrls}
+          imageUrl={performance.imageUrl}
         />
       ))}
       {hasMore && (
@@ -129,12 +129,12 @@ function MyPerformanceCard({
   startTime,
   endTime,
   performanceLocationName,
-  imageUrls,
+  imageUrl,
 }: MyPerformanceCardProps) {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const { mutate: deleteMyPerformance, isPending: isDeletePending } = useDeletePerformance();
   const { date, time } = formatPerformanceTime(startTime, endTime);
-  const thumbnailSrc = imageUrls[0];
+  const thumbnailSrc = imageUrl;
 
   return (
     <>

--- a/src/app/busking-map/_components/detail-panel.tsx
+++ b/src/app/busking-map/_components/detail-panel.tsx
@@ -42,7 +42,7 @@ interface LocationPerformanceItem {
   performanceDate: string;
   startTime: string;
   endTime: string;
-  images: string[];
+  imageUrl?: string;
 }
 
 interface LocationPerformancesResponse {
@@ -214,7 +214,7 @@ function LocationPerformancesSection({ performanceLocationId }: { performanceLoc
       return {
         id: String(item.performanceId),
         dateText: formatPerformanceDateText(item),
-        imageUrl: item.images?.[0] ?? null,
+        imageUrl: item.imageUrl ?? null,
         title: item.title ?? '',
       };
     });

--- a/src/components/performance/performance-card/performance-card.tsx
+++ b/src/components/performance/performance-card/performance-card.tsx
@@ -16,9 +16,9 @@ interface PerformanceCardProps {
 
 export const PerformanceCard = memo(({ performance, href, className }: PerformanceCardProps) => {
   const [imageError, setImageError] = useState(false);
-  const { title, performanceDate, startTime, endTime, locationName, images } = performance;
+  const { title, performanceDate, startTime, endTime, locationName, imageUrl } = performance;
 
-  const showPlaceholder = !images[0] || imageError;
+  const showPlaceholder = !imageUrl || imageError;
   const formattedDate = performanceDate.replaceAll('-', '.');
 
   return (
@@ -63,7 +63,7 @@ export const PerformanceCard = memo(({ performance, href, className }: Performan
                 )
               : (
                   <Image
-                    src={images[0]}
+                    src={imageUrl!}
                     alt={`${title} 포스터`}
                     fill
                     className={cn(`

--- a/src/types/performance/performance-list.ts
+++ b/src/types/performance/performance-list.ts
@@ -12,8 +12,8 @@ export interface Performance {
   endTime: string;
   /** 공연 장소명 */
   locationName: string;
-  /** 공연 이미지 URL 배열 */
-  images: string[];
+  /** 공연 이미지 URL */
+  imageUrl?: string | null;
 }
 
 /** 공연 목록 타입 */

--- a/src/utils/seo/performance-json-ld.ts
+++ b/src/utils/seo/performance-json-ld.ts
@@ -29,9 +29,9 @@ export function buildPerformanceEventJsonLd(
   performanceId: number,
   performanceDetail: PerformanceDetailResponseDto,
 ): WithContext<Event> {
-  const imageUrls = performanceDetail.images
-    .filter(imageUrl => imageUrl.trim().length > 0)
-    .map(toAbsoluteImageUrl);
+  const absoluteImageUrl = performanceDetail.imageUrl?.trim()
+    ? toAbsoluteImageUrl(performanceDetail.imageUrl)
+    : undefined;
 
   return {
     '@context': 'https://schema.org',
@@ -44,8 +44,8 @@ export function buildPerformanceEventJsonLd(
     'eventAttendanceMode': 'https://schema.org/OfflineEventAttendanceMode',
     'eventStatus': 'https://schema.org/EventScheduled',
     'inLanguage': 'ko-KR',
-    ...(imageUrls.length > 0 && {
-      image: imageUrls,
+    ...(absoluteImageUrl && {
+      image: absoluteImageUrl,
     }),
     'location': {
       '@type': 'Place',


### PR DESCRIPTION
## 관련 이슈
Closes #264

## 변경사항
- 공연 조회 응답의 이미지 필드를 `images` 배열에서 `imageUrl` 단일 필드로 변경했습니다.
- 목록, 상세, 프로필, 지도 패널의 이미지 참조 방식을 수정했습니다.
- 상세 메타데이터와 JSON-LD에 단일 이미지 URL을 반영했습니다.

## 리뷰 포인트
- 각 공연 GET API가 모두 `imageUrl` contract로 통일되었는지 확인해 주세요.
- 이미지가 `null` 또는 누락된 경우 기존 placeholder가 정상 노출되는지 확인해 주세요.