### PR TITLE
feat: 내정보 / 내가 등록한 공연 페이지 모바일 뷰 대응

### DIFF
--- a/src/app/(main)/profile/_components/footer.tsx
+++ b/src/app/(main)/profile/_components/footer.tsx
@@ -1,7 +1,11 @@
 // !todo: 공통 컴포넌트로 분리 예정
 export function Footer() {
   return (
-    <footer className="w-full border-t border-gray-100 bg-white py-14">
+    <footer className={`
+      hidden w-full border-t border-gray-100 bg-white py-14
+      md:block
+    `}
+    >
       <div className="flex items-start justify-between gap-12">
         <div className="flex items-center gap-3">
           <span className="text-title-4 font-bold tracking-tight text-primary">

--- a/src/app/(main)/profile/_components/profile-edit-modal.tsx
+++ b/src/app/(main)/profile/_components/profile-edit-modal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { SubmitHandler } from 'react-hook-form';
 import type { UpdateMemberNameRequestDto } from '@/apis/user';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect } from 'react';
@@ -7,8 +8,11 @@ import { useForm } from 'react-hook-form';
 import { UpdateMemberNameRequestDtoSchema } from '@/apis/user/user.schema';
 import { Button } from '@/components/common/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/common/dialog';
+import { AvatarCircleIcon } from '@/components/common/icon';
 import { FormInput } from '@/components/common/input';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/common/sheet';
 import { useUpdateMemberName } from '@/hooks/member/use-update-member-name';
+import { useMediaQuery } from '@/hooks/use-media-query';
 
 interface ProfileEditModalProps {
   open: boolean;
@@ -16,8 +20,19 @@ interface ProfileEditModalProps {
   currentName: string;
 }
 
+interface ProfileEditViewProps {
+  open: boolean;
+  isPending: boolean;
+  nameValue: string;
+  errors: ReturnType<typeof useForm<UpdateMemberNameRequestDto>>['formState']['errors'];
+  register: ReturnType<typeof useForm<UpdateMemberNameRequestDto>>['register'];
+  onSubmit: (e?: React.BaseSyntheticEvent) => Promise<void>;
+  onOpenChange: (open: boolean) => void;
+}
+
 export function ProfileEditModal({ open, onOpenChange, currentName }: ProfileEditModalProps) {
   const { mutate: updateName, isPending } = useUpdateMemberName();
+  const isMobile = useMediaQuery('(max-width: 767px)');
 
   const {
     register,
@@ -32,7 +47,6 @@ export function ProfileEditModal({ open, onOpenChange, currentName }: ProfileEdi
     reValidateMode: 'onSubmit',
   });
 
-  // 모달이 열릴 때마다 현재 닉네임으로 초기화
   useEffect(() => {
     if (open)
       reset({ name: currentName });
@@ -40,25 +54,103 @@ export function ProfileEditModal({ open, onOpenChange, currentName }: ProfileEdi
 
   const nameValue = watch('name') ?? '';
 
-  const onSubmit = (data: UpdateMemberNameRequestDto) => {
+  const handleFormSubmit: SubmitHandler<UpdateMemberNameRequestDto> = (data) => {
     updateName(data, { onSuccess: () => onOpenChange(false) });
   };
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!isPending)
+      onOpenChange(nextOpen);
+  };
+
+  const viewProps: ProfileEditViewProps = {
+    open,
+    isPending,
+    nameValue,
+    errors,
+    register,
+    onSubmit: handleSubmit(handleFormSubmit),
+    onOpenChange: handleOpenChange,
+  };
+
+  if (isMobile) {
+    return <MobileProfileEditModal {...viewProps} />;
+  }
+
+  return <DesktopProfileEditModal {...viewProps} />;
+}
+
+function MobileProfileEditModal({
+  open,
+  isPending,
+  nameValue,
+  errors,
+  register,
+  onSubmit,
+  onOpenChange,
+}: ProfileEditViewProps) {
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(nextOpen) => {
-        if (!isPending)
-          onOpenChange(nextOpen);
-      }}
-    >
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" rounded className="px-5">
+        <SheetHeader align="center">
+          <SheetTitle className="typo-title-b-5">프로필 변경</SheetTitle>
+        </SheetHeader>
+
+        <form
+          onSubmit={onSubmit}
+          className="flex flex-col items-center gap-6 pb-5"
+        >
+          <div className={`
+            flex size-20 items-center justify-center rounded-full bg-gray-200
+          `}
+          >
+            <AvatarCircleIcon className="size-14 text-gray-400" />
+          </div>
+
+          <FormInput
+            label="닉네임"
+            placeholder="닉네임을 입력해 주세요"
+            showCount
+            maxLength={15}
+            currentCount={nameValue.length}
+            error={errors.name?.message}
+            {...register('name')}
+          />
+
+          <Button
+            type="submit"
+            theme="orange"
+            appearance="filled"
+            size="md"
+            className="w-50"
+            disabled={isPending}
+          >
+            변경
+          </Button>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function DesktopProfileEditModal({
+  open,
+  isPending,
+  nameValue,
+  errors,
+  register,
+  onSubmit,
+  onOpenChange,
+}: ProfileEditViewProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         showCloseButton={false}
         className="w-143.75 gap-0 px-28.5 py-16.25"
       >
         <DialogTitle className="typo-body-sb-1 text-black">닉네임 변경</DialogTitle>
         <form
-          onSubmit={handleSubmit(onSubmit)}
+          onSubmit={onSubmit}
           className="mt-12.5 flex flex-col gap-16.75"
         >
           <FormInput

--- a/src/app/(main)/profile/_components/profile-edit-modal.tsx
+++ b/src/app/(main)/profile/_components/profile-edit-modal.tsx
@@ -107,15 +107,7 @@ function MobileProfileEditModal({
             <AvatarCircleIcon className="size-14 text-gray-400" />
           </div>
 
-          <FormInput
-            label="닉네임"
-            placeholder="닉네임을 입력해 주세요"
-            showCount
-            maxLength={15}
-            currentCount={nameValue.length}
-            error={errors.name?.message}
-            {...register('name')}
-          />
+          <ProfileNameInput nameValue={nameValue} errors={errors} register={register} />
 
           <Button
             type="submit"
@@ -153,15 +145,7 @@ function DesktopProfileEditModal({
           onSubmit={onSubmit}
           className="mt-12.5 flex flex-col gap-16.75"
         >
-          <FormInput
-            label="닉네임"
-            placeholder="닉네임을 입력해 주세요"
-            showCount
-            maxLength={15}
-            currentCount={nameValue.length}
-            error={errors.name?.message}
-            {...register('name')}
-          />
+          <ProfileNameInput nameValue={nameValue} errors={errors} register={register} />
           <div className="flex justify-center gap-2.5">
             <Button
               type="button"
@@ -186,5 +170,23 @@ function DesktopProfileEditModal({
         </form>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function ProfileNameInput({
+  nameValue,
+  errors,
+  register,
+}: Pick<ProfileEditViewProps, 'nameValue' | 'errors' | 'register'>) {
+  return (
+    <FormInput
+      label="닉네임"
+      placeholder="닉네임을 입력해 주세요"
+      showCount
+      maxLength={15}
+      currentCount={nameValue.length}
+      error={errors.name?.message}
+      {...register('name')}
+    />
   );
 }

--- a/src/app/(main)/profile/_components/profile-info.tsx
+++ b/src/app/(main)/profile/_components/profile-info.tsx
@@ -32,10 +32,10 @@ export function ProfileInfo() {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
-    <section className={`
-      flex w-full flex-col items-center gap-12.5
-      md:gap-16.75
-    `}
+    <section className={cn(
+      'flex w-full flex-col items-center gap-12.5',
+      'md:gap-16.75',
+    )}
     >
       {/* 아바타 아이콘 */}
       <div className={`
@@ -50,19 +50,19 @@ export function ProfileInfo() {
       </div>
 
       {/* 프로필 정보 */}
-      <div className={`
-        relative flex w-full flex-col gap-7.5 px-1.5
-        md:max-w-91.5 md:px-0
-      `}
+      <div className={cn(
+        'relative flex w-full flex-col gap-7.5 px-1.5',
+        'md:max-w-91.5 md:px-0',
+      )}
       >
         <Button
           theme="orange"
           appearance="outline"
           size="xs"
-          className={`
-            absolute right-1.5
-            md:right-0
-          `}
+          className={cn(
+            'absolute right-1.5',
+            'md:right-0',
+          )}
           onClick={() => setIsModalOpen(true)}
         >
           수정하기
@@ -72,10 +72,10 @@ export function ProfileInfo() {
       </div>
 
       {/* 이탈 버튼 */}
-      <div className={`
-        flex w-full justify-center gap-3 px-9 pt-[15px]
-        md:w-auto md:gap-2.5 md:px-0 md:pt-0
-      `}
+      <div className={cn(
+        'flex w-full justify-center gap-3 px-9 pt-[15px]',
+        'md:w-auto md:gap-2.5 md:px-0 md:pt-0',
+      )}
       >
         <Button
           theme="lightOrange"

--- a/src/app/(main)/profile/_components/profile-info.tsx
+++ b/src/app/(main)/profile/_components/profile-info.tsx
@@ -19,6 +19,12 @@ interface DisplayInputProps {
   value?: string | number;
 }
 
+const exitButtonClassName = cn(
+  'h-11 w-33.75',
+  'sm:h-15 sm:min-w-0 sm:flex-1',
+  'md:h-11.25 md:min-w-37.5 md:flex-none',
+);
+
 export function ProfileInfo() {
   const { data: { email, name } } = useSuspenseQuery(userQueryOptions);
   const { logout, isLogoutPending } = useAuth();
@@ -26,29 +32,37 @@ export function ProfileInfo() {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
-    <section className="flex w-full flex-col items-center gap-16.75">
+    <section className={`
+      flex w-full flex-col items-center gap-12.5
+      md:gap-16.75
+    `}
+    >
       {/* 아바타 아이콘 */}
-      <div className="flex items-center justify-center">
-        <div className={`
-          flex size-[85.85px] items-center justify-center rounded-full
-          bg-gray-200
-        `}
-        >
-          <AvatarCircleIcon
-            aria-hidden={true}
-            width={80}
-            height={80}
-          />
-        </div>
+      <div className={`
+        flex size-[85.85px] items-center justify-center rounded-full bg-gray-200
+      `}
+      >
+        <AvatarCircleIcon
+          aria-hidden={true}
+          width={80}
+          height={80}
+        />
       </div>
 
       {/* 프로필 정보 */}
-      <div className="relative flex w-full flex-col gap-7.5 px-91.5">
+      <div className={`
+        relative flex w-full flex-col gap-7.5 px-1.5
+        md:max-w-91.5 md:px-0
+      `}
+      >
         <Button
           theme="orange"
           appearance="outline"
           size="xs"
-          className="absolute right-0 mr-91.5"
+          className={`
+            absolute right-1.5
+            md:right-0
+          `}
           onClick={() => setIsModalOpen(true)}
         >
           수정하기
@@ -58,11 +72,22 @@ export function ProfileInfo() {
       </div>
 
       {/* 이탈 버튼 */}
-      <div className="flex gap-2.5">
-        <Button theme="lightOrange" size="md">회원탈퇴</Button>
+      <div className={`
+        flex w-full justify-center gap-3 px-9 pt-[15px]
+        md:w-auto md:gap-2.5 md:px-0 md:pt-0
+      `}
+      >
+        <Button
+          theme="lightOrange"
+          size="md"
+          className={exitButtonClassName}
+        >
+          회원탈퇴
+        </Button>
         <Button
           theme="gray"
           size="md"
+          className={exitButtonClassName}
           disabled={isLogoutPending}
           onClick={() => void logout()}
         >
@@ -92,8 +117,9 @@ export function DisplayInput({
       <div
         className={cn(
           `
-            flex h-15 w-full items-center rounded-full border border-gray-300
-            bg-gray-100 p-5
+            flex h-[55px] w-full items-center rounded-full border
+            border-gray-300 bg-gray-100 px-6
+            md:h-15 md:p-5
           `,
           'typo-body-m-3',
           'cursor-default outline-none',

--- a/src/app/(main)/profile/_components/profile-performances.tsx
+++ b/src/app/(main)/profile/_components/profile-performances.tsx
@@ -8,6 +8,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useCallback, useRef, useState } from 'react';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/common/dropdown-menu';
+import { Skeleton } from '@/components/common/skeleton';
 import { Spinner } from '@/components/common/spinner';
 import { PerformanceDeleteConfirmDialog, PerformanceRegisterButton } from '@/components/performance';
 import { useDeletePerformance } from '@/hooks/performance';
@@ -51,18 +52,33 @@ export function ProfilePerformances() {
   const performances = data.pages.flatMap(page => page.content);
 
   return (
-    <div className="flex w-full flex-1 flex-col">
+    <div className={`
+      flex w-full flex-1 flex-col px-1.5
+      md:px-0
+    `}
+    >
+      <h1 className={`
+        mb-2.5 py-5 typo-title-b-5 text-black
+        md:hidden
+      `}
+      >
+        내가 등록한 공연
+      </h1>
       {performances.length === 0
         ? (
             <EmptyPerformances />
           )
         : (
             <>
-              {/*
-            absolute 버튼: 이 div는 relative 없음
-            → 상위 profile-tab.tsx의 div.relative 기준으로 위치됨
-          */}
-              <PerformanceRegisterButton className="absolute -top-17.5 right-0" theme="lightGray" size="md">
+              <PerformanceRegisterButton
+                className={`
+                  mb-2.5 self-start
+                  md:absolute md:-top-17.5 md:right-0 md:mb-0
+                `}
+                theme="lightGray"
+                size="md"
+                mobileSize="sm"
+              >
                 내 공연 등록하기
               </PerformanceRegisterButton>
               <Performances
@@ -99,7 +115,11 @@ function Performances({ performances, onLoadMore, hasMore, isLoading }: Performa
   }, [onLoadMore]);
 
   return (
-    <section className="flex w-full flex-1 flex-col gap-7.5">
+    <section className={`
+      flex w-full flex-1 flex-col gap-[15px]
+      md:gap-7.5
+    `}
+    >
       {performances.map(performance => (
         <MyPerformanceCard
           key={performance.performanceId}
@@ -139,13 +159,15 @@ function MyPerformanceCard({
   return (
     <>
       <article className={`
-        relative flex w-full items-center rounded-lg bg-white p-2.5
+        relative flex w-full items-center rounded-lg bg-white p-2
         shadow-elevate-2
+        md:p-2.5
       `}
       >
         {/* 썸네일 */}
         <div className={`
-          relative h-45 w-37.5 shrink-0 overflow-hidden rounded-lg bg-gray-300
+          relative h-30 w-25 shrink-0 overflow-hidden rounded-lg bg-gray-300
+          md:h-45 md:w-37.5
         `}
         >
           {thumbnailSrc && (
@@ -154,16 +176,24 @@ function MyPerformanceCard({
               alt={title}
               fill
               className="object-cover"
-              sizes="150px"
+              sizes="(min-width: 768px) 150px, 100px"
             />
           )}
         </div>
 
         {/* 콘텐츠 */}
-        <div className="flex h-45 flex-1 flex-col justify-center gap-7.5 px-10">
+        <div className={`
+          flex h-30 min-w-0 flex-1 flex-col justify-center gap-3 px-4
+          md:h-45 md:gap-7.5 md:px-10
+        `}
+        >
           {/* 상단: 제목 + 더보기 */}
           <div className="flex items-center justify-between">
-            <h3 className="typo-body-sb-1 text-black">
+            <h3 className={`
+              min-w-0 flex-1 truncate typo-body-sb-2 text-black
+              md:typo-body-sb-1
+            `}
+            >
               {/*
                 ::after overlay 패턴: 이 <a> 의 ::after 가 <article> 전체를 덮어
                 카드 아무 곳이나 클릭하면 상세로 이동. nesting 없음.
@@ -171,7 +201,7 @@ function MyPerformanceCard({
               <Link
                 href={routePaths.performanceDetail(performanceId)}
                 className={`
-                  text-black outline-0
+                  block truncate text-black outline-0
                   after:absolute after:inset-0 after:content-['']
                   focus-visible:underline
                 `}
@@ -190,7 +220,11 @@ function MyPerformanceCard({
 
           {/* 하단: 날짜/시간 + 장소 */}
           <div className="flex flex-col gap-1.25">
-            <div className="typo-caption-m-1 text-gray-700">
+            <div className={`
+              typo-caption-r-1 text-gray-700
+              md:typo-caption-m-1
+            `}
+            >
               <p>{date}</p>
               <p>{time}</p>
             </div>
@@ -203,7 +237,11 @@ function MyPerformanceCard({
                 aria-hidden="true"
                 unoptimized
               />
-              <p className="typo-caption-m-1 text-gray-700">
+              <p className={`
+                truncate typo-caption-r-1 text-gray-700
+                md:typo-caption-m-1
+              `}
+              >
                 {performanceLocationName}
               </p>
             </div>
@@ -308,5 +346,63 @@ function EmptyPerformances() {
         </PerformanceRegisterButton>
       </div>
     </section>
+  );
+}
+
+function MyPerformanceCardSkeleton() {
+  return (
+    <div className={`
+      flex w-full items-center rounded-lg bg-white p-2 shadow-elevate-2
+      md:p-2.5
+    `}
+    >
+      <Skeleton className={`
+        h-30 w-25 shrink-0 rounded-lg
+        md:h-45 md:w-37.5
+      `}
+      />
+      <div className={`
+        flex h-30 flex-1 flex-col justify-center gap-3 px-4
+        md:h-45 md:gap-7.5 md:px-10
+      `}
+      >
+        <Skeleton className="h-5 w-3/4 rounded" />
+        <div className="flex flex-col gap-1.25">
+          <Skeleton className="h-3.5 w-2/3 rounded" />
+          <Skeleton className="h-3.5 w-1/2 rounded" />
+          <Skeleton className="h-3.5 w-1/2 rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ProfilePerformancesSkeleton() {
+  return (
+    <div className={`
+      flex w-full flex-1 flex-col px-1.5
+      md:px-0
+    `}
+    >
+      <div className={`
+        mb-2.5 h-17
+        md:hidden
+      `}
+      />
+      <Skeleton className={`
+        mb-2.5 h-9 w-30 self-start rounded-full
+        md:hidden
+      `}
+      />
+      <div className={`
+        flex w-full flex-1 flex-col gap-[15px]
+        md:gap-7.5
+      `}
+      >
+        {Array.from({ length: 4 }).map((_, i) => (
+          <MyPerformanceCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
   );
 }

--- a/src/app/(main)/profile/_components/profile-performances.tsx
+++ b/src/app/(main)/profile/_components/profile-performances.tsx
@@ -57,13 +57,13 @@ export function ProfilePerformances() {
       md:px-0
     `}
     >
-      <h1 className={`
+      <h2 className={`
         mb-2.5 py-5 typo-title-b-5 text-black
         md:hidden
       `}
       >
         내가 등록한 공연
-      </h1>
+      </h2>
       {performances.length === 0
         ? (
             <EmptyPerformances />

--- a/src/app/(main)/profile/_components/profile-tab.tsx
+++ b/src/app/(main)/profile/_components/profile-tab.tsx
@@ -5,7 +5,7 @@ import { Suspense } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/common/tags/tabs';
 import { cn } from '@/utils';
 import { ProfileInfo } from './profile-info';
-import { ProfilePerformances } from './profile-performances';
+import { ProfilePerformances, ProfilePerformancesSkeleton } from './profile-performances';
 
 interface ProfileTabTriggerProps {
   filter: 'my-info' | 'my-performances';
@@ -36,14 +36,26 @@ function BaseProfileTab() {
   };
 
   return (
-    <div className="flex w-full flex-1 flex-col pt-21.25">
+    <div className={`
+      flex w-full flex-1 flex-col pt-5
+      md:pt-21.25
+    `}
+    >
       <Tabs
         value={activeTab}
         onValueChange={handleTabChange}
         className="flex min-h-125 flex-1"
       >
-        <div className="flex w-full flex-row gap-11">
-          <div className="flex w-55 flex-col">
+        <div className={`
+          flex w-full flex-1 flex-col
+          md:flex-row md:gap-11
+        `}
+        >
+          <div className={`
+            hidden w-55 flex-col
+            md:flex
+          `}
+          >
             <h1 className="mb-25 pl-5 typo-title-sb-2 text-black">마이페이지</h1>
 
             <TabsList className="h-auto w-full flex-col bg-transparent p-0">
@@ -54,7 +66,7 @@ function BaseProfileTab() {
             </TabsList>
           </div>
 
-          <div className="flex flex-1 flex-col">
+          <div className="flex w-full flex-1 flex-col">
             <TabsContent
               value="my-info"
               className="mt-0 flex flex-1 outline-none"
@@ -64,9 +76,14 @@ function BaseProfileTab() {
 
             <TabsContent
               value="my-performances"
-              className="relative mt-40 flex flex-1 outline-none"
+              className={`
+                relative mt-0 flex flex-1 outline-none
+                md:mt-40
+              `}
             >
-              <ProfilePerformances />
+              <Suspense fallback={<ProfilePerformancesSkeleton />}>
+                <ProfilePerformances />
+              </Suspense>
             </TabsContent>
           </div>
         </div>


### PR DESCRIPTION
## 관련 이슈
Closes #270

## 변경사항
- 모바일에서 프로필 탭과 Footer를 숨기고 내정보 레이아웃을 조정했습니다.
- 모바일 프로필 수정 UI를 Bottom Sheet로 제공했습니다.
- 내가 등록한 공연 목록에 모바일 전용 제목, 반응형 카드, 로딩 스켈레톤을 적용했습니다.

## 리뷰 포인트
- 모바일에서는 Header 링크로 콘텐츠를 선택하고 데스크탑에서는 기존 탭을 유지하는 구조가 적절한지 확인해 주세요.
- 프로필 수정 UI가 viewport에 따라 Dialog와 Bottom Sheet로 분리되는 방식이 적절한지 확인해 주세요.
- 중간 너비에서도 프로필 정보와 공연 카드 레이아웃이 안정적으로 유지되는지 확인해 주세요.