### PR TITLE
fix 공연 카드 및 공연 프리뷰 캐러셀에 누락된 디자인 시안 반영

### DIFF
--- a/src/app/(main)/_components/upcoming-busking-carousel.tsx
+++ b/src/app/(main)/_components/upcoming-busking-carousel.tsx
@@ -12,7 +12,7 @@ export function UpcomingBuskingCarousel() {
     <EmblaCardCarousel
       perView={{ base: 2, md: 3, lg: 4 }}
       slidesToScroll={1}
-      gapPx={24}
+      gapPx={4.5}
       showArrows={true}
       showProgress={true}
       progressVariant="thumb"

--- a/src/components/performance/performance-card/performance-card-skeleton.tsx
+++ b/src/components/performance/performance-card/performance-card-skeleton.tsx
@@ -17,7 +17,7 @@ export function PerformanceCardSkeleton({ className }: PerformanceCardSkeletonPr
         className,
       )}
     >
-      <CardContent className="flex h-full flex-col p-2.5">
+      <CardContent className="flex h-full flex-col p-[4.5px]">
         <Skeleton className="aspect-5/8 w-full shrink-0 rounded-lg" />
         <div className={`
           flex flex-1 flex-col gap-1.5 p-1.5

--- a/src/components/performance/performance-card/performance-card.tsx
+++ b/src/components/performance/performance-card/performance-card.tsx
@@ -38,7 +38,7 @@ export const PerformanceCard = memo(({ performance, href, className }: Performan
         role="article"
         aria-label={`${title} 공연 카드`}
       >
-        <CardContent className="flex h-full flex-col p-2.5">
+        <CardContent className="flex h-full flex-col p-[4.5px]">
           {/* Thumbnail */}
           <div className={`
             relative aspect-5/8 w-full shrink-0 overflow-hidden rounded-lg

--- a/src/components/performance/performance-card/performance-card.tsx
+++ b/src/components/performance/performance-card/performance-card.tsx
@@ -41,8 +41,9 @@ export const PerformanceCard = memo(({ performance, href, className }: Performan
         <CardContent className="flex h-full flex-col p-[4.5px]">
           {/* Thumbnail */}
           <div className={`
-            relative aspect-5/8 w-full shrink-0 overflow-hidden rounded-lg
+            relative aspect-5/8 w-full shrink-0 overflow-hidden rounded-sm
             bg-muted
+            md:rounded-lg
           `}
           >
             {showPlaceholder


### PR DESCRIPTION
## 관련 이슈
Closes #272

## 변경사항
- 공연 프리뷰 캐러셀의 슬라이드 간격을 조정했습니다.
- 공연 카드와 스켈레톤의 내부 패딩을 디자인 시안에 맞췄습니다.
- 모바일 뷰에서 공연 카드 썸네일의 border-radius를 조정했습니다.

## 리뷰 포인트
- 모바일과 데스크탑에서 카드 간격이 디자인 시안과 일치하는지 확인해 주세요.
- `md` breakpoint 전후로 썸네일 border-radius가 적절하게 적용되는지 확인해 주세요.