### PR TITLE
feat: about-us 페이지 반응형 레이아웃 적용

### DIFF
--- a/src/app/(main)/about-us/_components/about-us-hero-section.tsx
+++ b/src/app/(main)/about-us/_components/about-us-hero-section.tsx
@@ -10,12 +10,19 @@ interface AboutUsHeroSectionProps {
 
 export function AboutUsHeroSection({ logoSrc, headline, description }: AboutUsHeroSectionProps) {
   return (
-    <section className="relative h-275 w-full overflow-hidden">
+    <section className={`
+      relative w-full overflow-hidden py-18
+      md:py-28
+      lg:h-275 lg:py-0
+    `}
+    >
       <div
         className={cn(
           'pointer-events-none absolute',
           'top-1/2 left-1/2',
-          'h-266 w-375 -translate-x-2/3 -translate-y-1/2',
+          'h-180 w-180 -translate-x-1/2 -translate-y-1/2',
+          'md:h-220 md:w-220',
+          'lg:h-266 lg:w-375 lg:-translate-x-2/3',
           'rounded-full',
           'bg-[radial-gradient(circle,#FF6138_0%,rgba(255,97,56,0)_100%)]',
           'opacity-10 blur-lg',
@@ -23,24 +30,45 @@ export function AboutUsHeroSection({ logoSrc, headline, description }: AboutUsHe
         aria-hidden
       />
 
-      <MainLayout className="flex h-full items-center">
+      <MainLayout className={`
+        relative z-10 flex items-center px-5
+        md:px-6
+        lg:h-full
+      `}
+      >
         <div className={`
-          mx-auto flex -translate-y-8 flex-col items-center justify-center
-          text-center
+          mx-auto flex flex-col items-center justify-center text-center
+          lg:-translate-y-8
         `}
         >
-          <Image src={logoSrc} alt="UNIBUSK" draggable={false} width={400} height={270} priority />
+          <Image
+            src={logoSrc}
+            alt="UNIBUSK"
+            draggable={false}
+            width={400}
+            height={270}
+            priority
+            className={`
+              h-auto w-34
+              md:w-40
+              lg:w-100
+            `}
+          />
 
-          <h1 className={cn('mt-6 break-keep whitespace-pre-line', `
-            typo-title-sb-2 text-gray-800
-          `)}
+          <h1 className={cn(`
+            mt-6 max-w-85 typo-body-sb-2 break-keep whitespace-pre-line
+            md:max-w-120 md:typo-title-sb-5
+            lg:max-w-none lg:typo-title-sb-2
+          `, `text-gray-800`)}
           >
             {headline}
           </h1>
 
-          <p className={cn(`mt-18.75 max-w-238 break-keep whitespace-pre-line`, `
-            typo-title-r-4 text-gray-600
-          `)}
+          <p className={cn(`
+            mt-8 max-w-85 typo-caption-r-2 break-keep whitespace-normal
+            md:max-w-125 md:typo-caption-r-1
+            lg:mt-18.75 lg:max-w-238 lg:typo-title-r-4 lg:whitespace-pre-line
+          `, `text-gray-600`)}
           >
             {description}
           </p>

--- a/src/app/(main)/about-us/_components/about-us-moments-section.tsx
+++ b/src/app/(main)/about-us/_components/about-us-moments-section.tsx
@@ -24,11 +24,14 @@ export function AboutUsMomentsSection({ heading, items }: AboutUsMomentsSectionP
       `}
       >
         <h2
-          className={`
-            text-center typo-body-b-1 text-black
-            md:typo-title-b-5
-            lg:typo-title-b-1
-          `}
+          className={cn(
+            `
+              text-center typo-body-b-1
+              md:typo-title-b-5
+              lg:typo-title-b-1
+            `,
+            'text-black',
+          )}
         >
           {heading}
         </h2>
@@ -92,18 +95,24 @@ function MomentCard({
       )}
     >
       <h3
-        className={`
-          typo-caption-b-1 break-keep text-gray-800
-          lg:typo-title-b-3
-        `}
+        className={cn(
+          `
+            typo-caption-b-1 break-keep
+            lg:typo-title-b-3
+          `,
+          'text-gray-800',
+        )}
       >
         {title}
       </h3>
       <p
-        className={`
-          mt-3.5 typo-caption-r-2 break-keep whitespace-pre-line text-gray-700
-          lg:typo-title-r-4
-        `}
+        className={cn(
+          `
+            mt-3.5 typo-caption-r-2 break-keep whitespace-pre-line
+            lg:typo-title-r-4
+          `,
+          'text-gray-700',
+        )}
       >
         {description}
       </p>

--- a/src/app/(main)/about-us/_components/about-us-moments-section.tsx
+++ b/src/app/(main)/about-us/_components/about-us-moments-section.tsx
@@ -14,16 +14,43 @@ interface AboutUsMomentsSectionProps {
 export function AboutUsMomentsSection({ heading, items }: AboutUsMomentsSectionProps) {
   return (
     <section className={`
-      flex h-full min-h-350 w-full flex-col items-center justify-center bg-white
+      flex w-full flex-col items-center justify-center bg-white py-18
+      lg:h-full lg:min-h-350 lg:py-0
     `}
     >
-      <MainLayout>
-        <h2 className="text-center typo-title-b-1 text-black">{heading}</h2>
+      <MainLayout className={`
+        px-5
+        md:px-6
+      `}
+      >
+        <h2
+          className={`
+            text-center typo-body-b-1 text-black
+            md:typo-title-b-5
+            lg:typo-title-b-1
+          `}
+        >
+          {heading}
+        </h2>
 
-        <div className="mt-33.25 flex w-full flex-col items-center">
-          <div className="flex flex-col gap-16.5">
+        <div className={`
+          mt-12.5 flex w-full flex-col items-center
+          lg:mt-33.25
+        `}
+        >
+          <div className={`
+            flex w-full flex-col gap-5
+            lg:w-auto lg:gap-16.5
+          `}
+          >
             {items.map((item, index) => (
-              <div key={item.title} className="flex items-center gap-12">
+              <div
+                key={item.title}
+                className={`
+                  flex items-center
+                  lg:gap-12
+                `}
+              >
                 <TimelineDot
                   isLast={index === items.length - 1}
                   connectorVariant={index % 2 === 0 ? 'down-right' : 'down-left'}
@@ -52,20 +79,30 @@ function MomentCard({
   description: string;
   align: 'left' | 'right';
 }) {
-  const shiftClass = align === 'right' ? 'ml-20' : '';
+  const shiftClass = align === 'right' ? 'lg:ml-20' : '';
 
   return (
     <div
       className={cn(
-        'h-full min-h-46 w-full max-w-360 rounded-2xl bg-gray-200 px-12 py-10',
+        'w-full rounded-2xl bg-gray-200 px-5 py-6',
+        'md:px-8 md:py-7',
+        'lg:h-full lg:min-h-46 lg:max-w-360 lg:px-12 lg:py-10',
         'shadow-[0_6px_14px_rgba(0,0,0,0.10)] ring-1 ring-black/10',
         shiftClass,
       )}
     >
-      <h3 className="typo-title-b-3 break-keep text-gray-800">{title}</h3>
+      <h3
+        className={`
+          typo-caption-b-1 break-keep text-gray-800
+          lg:typo-title-b-3
+        `}
+      >
+        {title}
+      </h3>
       <p
         className={`
-          mt-3.5 typo-title-r-4 break-keep whitespace-pre-line text-gray-700
+          mt-3.5 typo-caption-r-2 break-keep whitespace-pre-line text-gray-700
+          lg:typo-title-r-4
         `}
       >
         {description}
@@ -102,7 +139,8 @@ function TimelineDot({
   return (
     <div
       className={`
-        relative flex h-46 w-30 items-center
+        hidden h-46 w-30 items-center
+        lg:relative lg:flex
         ${justifyClass}
       `}
       aria-hidden

--- a/src/app/(main)/about-us/_components/about-us-vision-section.tsx
+++ b/src/app/(main)/about-us/_components/about-us-vision-section.tsx
@@ -15,11 +15,32 @@ interface AboutUsVisionSectionProps {
 
 export function AboutUsVisionSection({ heading, cards }: AboutUsVisionSectionProps) {
   return (
-    <section className="h-275 w-full bg-orange-400">
-      <MainLayout className="flex h-full flex-col items-center justify-center">
-        <h2 className="text-center typo-title-b-1 text-white">{heading}</h2>
+    <section className={`
+      w-full bg-orange-400 py-18
+      lg:h-275 lg:py-0
+    `}
+    >
+      <MainLayout className={`
+        flex flex-col items-center justify-center px-5
+        md:px-6
+        lg:h-full
+      `}
+      >
+        <h2
+          className={`
+            text-center typo-body-b-1 text-white
+            md:typo-title-b-5
+            lg:typo-title-b-1
+          `}
+        >
+          {heading}
+        </h2>
 
-        <div className="mt-23 grid w-full grid-cols-3 gap-10">
+        <div className={`
+          mt-12.5 grid w-full grid-cols-1 gap-8
+          lg:mt-23 lg:grid-cols-3 lg:gap-10
+        `}
+        >
           {cards.map(card => (
             <VisionCardItem key={card.title} {...card} />
           ))}
@@ -34,15 +55,17 @@ function VisionCardItem({ iconSrc, title, description }: VisionCard) {
     <article
       className={cn(
         `
-          flex flex-col items-center rounded-3xl bg-white px-10 py-14
-          text-center
+          mx-auto flex w-full max-w-72.5 flex-col items-center rounded-3xl
+          bg-white px-7 py-9 text-center
         `,
+        'lg:max-w-none lg:px-10 lg:py-14',
         'shadow-[0_0_42.2px_rgba(255,255,255,1)]',
       )}
     >
       <div className={`
-        mx-auto flex h-25 w-25 items-center justify-center rounded-full
+        mx-auto flex h-15 w-15 items-center justify-center rounded-full
         bg-orange-150
+        lg:h-25 lg:w-25
       `}
       >
         <Image
@@ -50,21 +73,26 @@ function VisionCardItem({ iconSrc, title, description }: VisionCard) {
           alt=""
           width={50}
           height={50}
-          className="block object-contain"
+          className={`
+            block h-7.5 w-7.5 object-contain
+            lg:h-12.5 lg:w-12.5
+          `}
           aria-hidden
         />
       </div>
 
-      <h3 className={cn('mt-17.5 break-keep whitespace-pre-line', `
-        typo-title-sb-4 text-gray-800
-      `)}
+      <h3 className={cn(`
+        mt-8 typo-body-sb-3 break-keep whitespace-pre-line
+        lg:mt-17.5 lg:typo-title-sb-4
+      `, `text-gray-800`)}
       >
         {title}
       </h3>
 
-      <p className={cn('mt-12.5 w-full max-w-78', `
-        typo-body-sb-2 break-keep whitespace-pre-line text-gray-550
-      `)}
+      <p className={cn(`
+        mt-6 w-full max-w-60 typo-caption-m-2
+        lg:mt-12.5 lg:max-w-78 lg:typo-body-sb-2
+      `, `break-keep whitespace-pre-line text-gray-550`)}
       >
         {description}
       </p>

--- a/src/app/(main)/about-us/_components/about-us-vision-section.tsx
+++ b/src/app/(main)/about-us/_components/about-us-vision-section.tsx
@@ -27,11 +27,14 @@ export function AboutUsVisionSection({ heading, cards }: AboutUsVisionSectionPro
       `}
       >
         <h2
-          className={`
-            text-center typo-body-b-1 text-white
-            md:typo-title-b-5
-            lg:typo-title-b-1
-          `}
+          className={cn(
+            `
+              text-center typo-body-b-1
+              md:typo-title-b-5
+              lg:typo-title-b-1
+            `,
+            'text-white',
+          )}
         >
           {heading}
         </h2>

--- a/src/app/(main)/about-us/page.tsx
+++ b/src/app/(main)/about-us/page.tsx
@@ -1,4 +1,5 @@
 import { createPageMetadata } from '@/utils';
+import { HomeFooter } from '../_components';
 import {
   AboutUsHeroSection,
   AboutUsMomentsSection,
@@ -64,10 +65,13 @@ const MOMENT_ITEMS = [
 
 export default function AboutUsPage() {
   return (
-    <main className="w-full bg-white">
-      <AboutUsHeroSection {...HERO_ITEMS} />
-      <AboutUsVisionSection heading="UNIBUSK가 꿈꾸는 거리" cards={VISION_CARDS} />
-      <AboutUsMomentsSection heading="UNIBUSK가 연결하는 순간들" items={MOMENT_ITEMS} />
-    </main>
+    <>
+      <main className="w-full bg-white">
+        <AboutUsHeroSection {...HERO_ITEMS} />
+        <AboutUsVisionSection heading="UNIBUSK가 꿈꾸는 거리" cards={VISION_CARDS} />
+        <AboutUsMomentsSection heading="UNIBUSK가 연결하는 순간들" items={MOMENT_ITEMS} />
+      </main>
+      <HomeFooter />
+    </>
   );
 }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -40,6 +40,13 @@
   letter-spacing: -0.011em;
 }
 
+@utility typo-title-sb-5 {
+  font-size: var(--text-title-5);
+  line-height: 1.5;
+  font-weight: 600;
+  letter-spacing: -0.011em;
+}
+
 @utility typo-body-b-1 {
   font-size: var(--text-body-1);
   line-height: 1.5;
@@ -89,8 +96,22 @@
   letter-spacing: -0.011em;
 }
 
+@utility typo-caption-b-1 {
+  font-size: var(--text-caption-1);
+  line-height: 1.5;
+  font-weight: 700;
+  letter-spacing: -0.011em;
+}
+
 @utility typo-caption-m-1 {
   font-size: var(--text-caption-1);
+  line-height: 1.5;
+  font-weight: 500;
+  letter-spacing: -0.011em;
+}
+
+@utility typo-caption-m-2 {
+  font-size: var(--text-caption-2);
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: -0.011em;


### PR DESCRIPTION
## 관련 이슈

<!-- 이슈 번호를 입력하세요. -->

Closes #245 

## 변경사항

<!-- 주요 변경사항을 작성하세요. -->
- about-us 페이지를 모바일, 태블릿, 데스크톱 기준으로 분리

## 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->
- about-us 모바일/태블릿/데스크톱 레이아웃 전환 확인

## 추가 정보

<!-- 스크린샷, 테스트 방법 등 추가 정보가 있다면 작성하세요 -->
<img width="378" height="820" alt="image" src="https://github.com/user-attachments/assets/a5b5c981-da16-4070-a36d-195bba095bb7" />
