### PR TITLE
feat: 버스킹맵 페이지 반응형 작업

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-hook-form": "^7.70.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
+    "vaul": "^1.1.2",
     "zod": "^4.3.4",
     "zustand": "^5.0.10"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.3(react@19.0.3))(react@19.0.3)
       zod:
         specifier: ^4.3.4
         version: 4.3.4
@@ -7362,6 +7365,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vite-plugin-storybook-nextjs@3.1.8:
     resolution: {integrity: sha512-RPIt5pRz2p2MAqfjsDbODKfx8Q2ao/DNf0Sczhd4Hj5NEw6/OlWZk6lVSsF56s8i40Cca8IDPB59jZ+F8WYAtg==}
@@ -16390,6 +16399,15 @@ snapshots:
   uuid@9.0.1: {}
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.3(react@19.0.3))(react@19.0.3):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.3(react@19.0.3))(react@19.0.3)
+      react: 19.0.3
+      react-dom: 19.0.3(react@19.0.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vite-plugin-storybook-nextjs@3.1.8(next@15.3.8(@babel/core@7.28.5)(react-dom@19.0.3(react@19.0.3))(react@19.0.3))(storybook@10.1.11(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.0.3(react@19.0.3))(react@19.0.3))(typescript@5.9.3)(vite@7.3.0(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.16.9)(yaml@2.8.2)):
     dependencies:

--- a/src/app/(main)/profile/_components/profile-performances.tsx
+++ b/src/app/(main)/profile/_components/profile-performances.tsx
@@ -116,7 +116,7 @@ function Performances({ performances, onLoadMore, hasMore, isLoading }: Performa
 
   return (
     <section className={`
-      flex w-full flex-1 flex-col gap-[15px]
+      flex w-full flex-1 flex-col gap-3.75
       md:gap-7.5
     `}
     >
@@ -395,7 +395,7 @@ export function ProfilePerformancesSkeleton() {
       `}
       />
       <div className={`
-        flex w-full flex-1 flex-col gap-[15px]
+        flex w-full flex-1 flex-col gap-3.75
         md:gap-7.5
       `}
       >

--- a/src/app/busking-map/_components/busking-map-bottom-sheet.tsx
+++ b/src/app/busking-map/_components/busking-map-bottom-sheet.tsx
@@ -323,7 +323,7 @@ export function BuskingMapBottomSheet({
   const isDetailOpen = Boolean(selectedPlace || focusedPlace);
   const isCollapsed = activeSnapPoint === BUSKING_MAP_SHEET_SNAP.collapsed;
   const isDetailFullscreen = isDetailOpen && activeSnapPoint === BUSKING_MAP_SHEET_SNAP.detail;
-  const isExpanded = !isDetailFullscreen && !isCollapsed && activeSnapPoint !== BUSKING_MAP_SHEET_SNAP.default;
+  const isExpanded = !isDetailFullscreen && !isCollapsed && activeSnapPoint !== BUSKING_MAP_SHEET_SNAP.default && activeSnapPoint !== BUSKING_MAP_SHEET_SNAP.detail;
   const isExpandedSnapPoint = activeSnapPoint !== BUSKING_MAP_SHEET_SNAP.collapsed
     && activeSnapPoint !== BUSKING_MAP_SHEET_SNAP.default
     && activeSnapPoint !== BUSKING_MAP_SHEET_SNAP.detail;

--- a/src/app/busking-map/_components/busking-map-bottom-sheet.tsx
+++ b/src/app/busking-map/_components/busking-map-bottom-sheet.tsx
@@ -1,0 +1,422 @@
+'use client';
+
+import type { BuskingPlace, SidebarTab } from '@/types/busking-map';
+import Image from 'next/image';
+import { useEffect, useMemo, useReducer, useRef } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+} from '@/components/common/drawer';
+import { LineDivider } from '@/components/common/line-divider';
+import { useBuskingMapUiStore } from '@/stores/busking-map';
+import { cn } from '@/utils';
+import { DetailPanel } from './detail-panel';
+
+const BUSKING_MAP_SHEET_SNAP = {
+  collapsed: '116px',
+  default: 0.48,
+} as const;
+
+const MOBILE_HEADER_HEIGHT_FALLBACK_PX = 96;
+
+type BuskingMapSheetSnapPoint = number | string | null;
+
+interface BuskingMapBottomSheetProps {
+  activeTab: SidebarTab;
+  places: BuskingPlace[];
+  focusedPlace: BuskingPlace | null;
+  selectedPlace: BuskingPlace | null;
+  onTabClick: (tab: SidebarTab) => void;
+  onListItemClick: (placeId: string) => void;
+  onFocusedCloseClick: () => void;
+  onDetailCloseClick: () => void;
+}
+
+function BottomSheetTabs({
+  activeTab,
+  onTabClick,
+}: {
+  activeTab: SidebarTab;
+  onTabClick: (tab: SidebarTab) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="버스킹 장소 목록"
+      className="flex h-11 items-end justify-center gap-9"
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeTab === 'places'}
+        onClick={() => onTabClick('places')}
+        className={cn(
+          'h-9 cursor-pointer border-b-2 px-2 typo-caption-m-2 font-semibold',
+          activeTab === 'places'
+            ? 'border-primary text-primary'
+            : 'border-transparent text-gray-500',
+        )}
+      >
+        공연 장소
+      </button>
+
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeTab === 'search'}
+        onClick={() => onTabClick('search')}
+        className={cn(
+          'h-9 cursor-pointer border-b-2 px-2 typo-caption-m-2 font-semibold',
+          activeTab === 'search'
+            ? 'border-primary text-primary'
+            : 'border-transparent text-gray-500',
+        )}
+      >
+        검색 결과
+      </button>
+    </div>
+  );
+}
+
+function PlacePreviewCard({
+  place,
+  onClick,
+}: {
+  place: BuskingPlace | null;
+  onClick: () => void;
+}) {
+  if (!place) {
+    return (
+      <div className="px-5 pb-4 text-center">
+        <p className="typo-caption-r-1 text-gray-600">표시할 공연 장소가 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`
+        flex w-full cursor-pointer items-center gap-3 px-5 pb-4 text-left
+        outline-none
+        focus-visible:ring-2 focus-visible:ring-primary
+        focus-visible:ring-offset-2
+      `}
+    >
+      <div className={`
+        relative size-15 shrink-0 overflow-hidden rounded-lg bg-gray-200
+      `}
+      >
+        {place.thumbnailUrl
+          ? (
+              <Image
+                src={place.thumbnailUrl}
+                alt=""
+                fill
+                sizes="60px"
+                className="object-cover"
+              />
+            )
+          : null}
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="line-clamp-1 typo-body-sb-3 text-black">{place.title}</p>
+      </div>
+    </button>
+  );
+}
+
+function PlaceListItem({
+  place,
+  onClick,
+}: {
+  place: BuskingPlace;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`
+        flex w-full cursor-pointer gap-3 px-5 py-3 text-left outline-none
+        hover:bg-orange-150
+        focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset
+      `}
+    >
+      <div className={`
+        relative h-20 w-27 shrink-0 overflow-hidden rounded-lg bg-gray-200
+      `}
+      >
+        {place.thumbnailUrl
+          ? (
+              <Image
+                src={place.thumbnailUrl}
+                alt=""
+                fill
+                sizes="108px"
+                className="object-cover"
+              />
+            )
+          : null}
+      </div>
+
+      <div className="min-w-0 flex-1 py-1">
+        <h3 className="line-clamp-2 typo-body-sb-3 text-black">{place.title}</h3>
+      </div>
+    </button>
+  );
+}
+
+function PlaceList({
+  activeTab,
+  places,
+  onTabClick,
+  onListItemClick,
+}: {
+  activeTab: SidebarTab;
+  places: BuskingPlace[];
+  onTabClick: (tab: SidebarTab) => void;
+  onListItemClick: (placeId: string) => void;
+}) {
+  const isEmpty = places.length === 0;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col" data-vaul-no-drag>
+      <BottomSheetTabs activeTab={activeTab} onTabClick={onTabClick} />
+
+      <div
+        className={cn(
+          'min-h-0 flex-1',
+          isEmpty
+            ? 'flex items-center justify-center'
+            : 'overflow-y-auto',
+        )}
+      >
+        {isEmpty
+          ? (
+              <p className="px-5 text-center typo-body-m-3 text-gray-600">
+                {activeTab === 'search' ? '검색 결과가 없습니다.' : '표시할 공연 장소가 없습니다.'}
+              </p>
+            )
+          : (
+              <div className="pb-8">
+                {places.map((place, index) => (
+                  <div key={place.id}>
+                    <PlaceListItem place={place} onClick={() => onListItemClick(place.id)} />
+                    {index < places.length - 1
+                      ? <LineDivider width="89%" thickness={1} colorClassName="bg-gray-200" />
+                      : null}
+                  </div>
+                ))}
+              </div>
+            )}
+      </div>
+    </div>
+  );
+}
+
+export function BuskingMapBottomSheet({
+  activeTab,
+  places,
+  focusedPlace,
+  selectedPlace,
+  onTabClick,
+  onListItemClick,
+  onFocusedCloseClick,
+  onDetailCloseClick,
+}: BuskingMapBottomSheetProps) {
+  const [headerHeightPx, setHeaderHeightPx] = useReducer(
+    (_current: number, next: number) => next,
+    MOBILE_HEADER_HEIGHT_FALLBACK_PX,
+  );
+  const [activeSnapPoint, setActiveSnapPoint] = useReducer(
+    (_current: BuskingMapSheetSnapPoint, next: BuskingMapSheetSnapPoint) => next,
+    BUSKING_MAP_SHEET_SNAP.collapsed,
+  );
+
+  const mapState = useBuskingMapUiStore(
+    useShallow(state => ({
+      listScope: state.listScope,
+      searchQuery: state.searchQuery,
+      focusedPlaceId: state.focusedPlaceId,
+      selectedPlaceId: state.selectedPlaceId,
+    })),
+  );
+
+  const interactionKey = `${mapState.listScope}:${mapState.searchQuery}:${mapState.focusedPlaceId ?? ''}:${mapState.selectedPlaceId ?? ''}`;
+  const previousInteractionKeyRef = useRef(interactionKey);
+
+  const expandedSnapPoint = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return `calc(100dvh - ${MOBILE_HEADER_HEIGHT_FALLBACK_PX}px)`;
+    }
+
+    return `${Math.max(window.innerHeight - headerHeightPx, 0)}px`;
+  }, [headerHeightPx]);
+
+  const snapPoints = useMemo(() => {
+    return [
+      BUSKING_MAP_SHEET_SNAP.collapsed,
+      BUSKING_MAP_SHEET_SNAP.default,
+      expandedSnapPoint,
+    ];
+  }, [expandedSnapPoint]);
+
+  useEffect(() => {
+    const header = document.querySelector('header');
+    if (!header) {
+      return;
+    }
+
+    const updateHeaderHeight = () => {
+      const nextHeight = Math.round(header.getBoundingClientRect().height);
+      if (nextHeight > 0) {
+        setHeaderHeightPx(nextHeight);
+      }
+    };
+
+    updateHeaderHeight();
+
+    const resizeObserver = new ResizeObserver(updateHeaderHeight);
+    resizeObserver.observe(header);
+    window.addEventListener('resize', updateHeaderHeight);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', updateHeaderHeight);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (previousInteractionKeyRef.current === interactionKey) {
+      return;
+    }
+
+    previousInteractionKeyRef.current = interactionKey;
+
+    if (mapState.selectedPlaceId) {
+      setActiveSnapPoint(expandedSnapPoint);
+      return;
+    }
+
+    if (mapState.focusedPlaceId) {
+      setActiveSnapPoint(BUSKING_MAP_SHEET_SNAP.collapsed);
+      return;
+    }
+
+    if (mapState.listScope === 'cluster' || mapState.searchQuery.trim() !== '') {
+      setActiveSnapPoint(BUSKING_MAP_SHEET_SNAP.default);
+    }
+  }, [expandedSnapPoint, interactionKey, mapState.focusedPlaceId, mapState.listScope, mapState.searchQuery, mapState.selectedPlaceId]);
+
+  const previewPlace = useMemo(() => {
+    return selectedPlace ?? focusedPlace ?? places[0] ?? null;
+  }, [focusedPlace, places, selectedPlace]);
+
+  const isDetailOpen = Boolean(selectedPlace || focusedPlace);
+  const isCollapsed = activeSnapPoint === BUSKING_MAP_SHEET_SNAP.collapsed;
+  const isExpanded = !isCollapsed && activeSnapPoint !== BUSKING_MAP_SHEET_SNAP.default;
+
+  const handlePreviewClick = () => {
+    if (!previewPlace) {
+      return;
+    }
+
+    onListItemClick(previewPlace.id);
+    setActiveSnapPoint(expandedSnapPoint);
+  };
+
+  const handleListItemClick = (placeId: string) => {
+    onListItemClick(placeId);
+    setActiveSnapPoint(expandedSnapPoint);
+  };
+
+  const handleDetailCloseClick = () => {
+    if (selectedPlace) {
+      onDetailCloseClick();
+    }
+    else {
+      onFocusedCloseClick();
+    }
+
+    setActiveSnapPoint(BUSKING_MAP_SHEET_SNAP.default);
+  };
+
+  return (
+    <Drawer
+      open={true}
+      modal={false}
+      dismissible={false}
+      direction="bottom"
+      snapPoints={snapPoints}
+      activeSnapPoint={activeSnapPoint}
+      setActiveSnapPoint={setActiveSnapPoint}
+      snapToSequentialPoint={true}
+      shouldScaleBackground={false}
+      setBackgroundColorOnScale={false}
+      autoFocus={false}
+    >
+      <DrawerContent
+        showOverlay={false}
+        className={cn(
+          'z-sidebar mt-0! h-dvh! max-h-dvh! border-none! bg-white',
+          isExpanded ? 'shadow-none' : 'shadow-sidebar',
+          isExpanded
+            ? `
+              rounded-none
+              *:data-[slot=drawer-handle]:hidden
+              data-[vaul-drawer-direction=bottom]:rounded-none
+            `
+            : 'rounded-t-[20px]',
+        )}
+      >
+        <DrawerTitle className="sr-only">버스킹 장소 목록</DrawerTitle>
+
+        {isExpanded
+          ? (
+              <div
+                aria-hidden={true}
+                className="h-6 w-full shrink-0 bg-white"
+              />
+            )
+          : null}
+
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          {isDetailOpen && !isCollapsed
+            ? (
+                <div className="min-h-0 flex-1 px-2 pb-2">
+                  <DetailPanel
+                    place={selectedPlace ?? focusedPlace}
+                    onCloseClick={handleDetailCloseClick}
+                  />
+                </div>
+              )
+            : (
+                <>
+                  {isCollapsed
+                    ? (
+                        <PlacePreviewCard place={previewPlace} onClick={handlePreviewClick} />
+                      )
+                    : null}
+                  {!isCollapsed
+                    ? (
+                        <PlaceList
+                          activeTab={activeTab}
+                          places={places}
+                          onTabClick={onTabClick}
+                          onListItemClick={handleListItemClick}
+                        />
+                      )
+                    : null}
+                </>
+              )}
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/app/busking-map/_components/busking-map-bottom-sheet.tsx
+++ b/src/app/busking-map/_components/busking-map-bottom-sheet.tsx
@@ -18,6 +18,7 @@ import { DetailPanel } from './detail-panel';
 const BUSKING_MAP_SHEET_SNAP = {
   collapsed: '116px',
   default: 0.48,
+  detail: 1,
 } as const;
 
 const MOBILE_HEADER_HEIGHT_FALLBACK_PX = 96;
@@ -253,7 +254,7 @@ export function BuskingMapBottomSheet({
 
   const expandedSnapPoint = useMemo(() => {
     if (typeof window === 'undefined') {
-      return `calc(100dvh - ${MOBILE_HEADER_HEIGHT_FALLBACK_PX}px)`;
+      return `${MOBILE_HEADER_HEIGHT_FALLBACK_PX}px`;
     }
 
     return `${Math.max(window.innerHeight - headerHeightPx, 0)}px`;
@@ -264,6 +265,7 @@ export function BuskingMapBottomSheet({
       BUSKING_MAP_SHEET_SNAP.collapsed,
       BUSKING_MAP_SHEET_SNAP.default,
       expandedSnapPoint,
+      BUSKING_MAP_SHEET_SNAP.detail,
     ];
   }, [expandedSnapPoint]);
 
@@ -300,12 +302,12 @@ export function BuskingMapBottomSheet({
     previousInteractionKeyRef.current = interactionKey;
 
     if (mapState.selectedPlaceId) {
-      setActiveSnapPoint(expandedSnapPoint);
+      setActiveSnapPoint(BUSKING_MAP_SHEET_SNAP.detail);
       return;
     }
 
     if (mapState.focusedPlaceId) {
-      setActiveSnapPoint(BUSKING_MAP_SHEET_SNAP.collapsed);
+      setActiveSnapPoint(BUSKING_MAP_SHEET_SNAP.detail);
       return;
     }
 
@@ -320,7 +322,19 @@ export function BuskingMapBottomSheet({
 
   const isDetailOpen = Boolean(selectedPlace || focusedPlace);
   const isCollapsed = activeSnapPoint === BUSKING_MAP_SHEET_SNAP.collapsed;
-  const isExpanded = !isCollapsed && activeSnapPoint !== BUSKING_MAP_SHEET_SNAP.default;
+  const isDetailFullscreen = isDetailOpen && activeSnapPoint === BUSKING_MAP_SHEET_SNAP.detail;
+  const isExpanded = !isDetailFullscreen && !isCollapsed && activeSnapPoint !== BUSKING_MAP_SHEET_SNAP.default;
+  const isExpandedSnapPoint = activeSnapPoint !== BUSKING_MAP_SHEET_SNAP.collapsed
+    && activeSnapPoint !== BUSKING_MAP_SHEET_SNAP.default
+    && activeSnapPoint !== BUSKING_MAP_SHEET_SNAP.detail;
+
+  useEffect(() => {
+    if (!isExpandedSnapPoint) {
+      return;
+    }
+
+    setActiveSnapPoint(expandedSnapPoint);
+  }, [expandedSnapPoint, isExpandedSnapPoint]);
 
   const handlePreviewClick = () => {
     if (!previewPlace) {
@@ -328,12 +342,12 @@ export function BuskingMapBottomSheet({
     }
 
     onListItemClick(previewPlace.id);
-    setActiveSnapPoint(expandedSnapPoint);
+    setActiveSnapPoint(BUSKING_MAP_SHEET_SNAP.detail);
   };
 
   const handleListItemClick = (placeId: string) => {
     onListItemClick(placeId);
-    setActiveSnapPoint(expandedSnapPoint);
+    setActiveSnapPoint(BUSKING_MAP_SHEET_SNAP.detail);
   };
 
   const handleDetailCloseClick = () => {
@@ -362,22 +376,31 @@ export function BuskingMapBottomSheet({
       autoFocus={false}
     >
       <DrawerContent
+        direction="bottom"
         showOverlay={false}
         className={cn(
           'z-sidebar mt-0! h-dvh! max-h-dvh! border-none! bg-white',
-          isExpanded ? 'shadow-none' : 'shadow-sidebar',
-          isExpanded
+          isExpanded || isDetailFullscreen ? 'shadow-none' : 'shadow-sidebar',
+          isExpanded || isDetailFullscreen
             ? `
               rounded-none
-              *:data-[slot=drawer-handle]:hidden
               data-[vaul-drawer-direction=bottom]:rounded-none
             `
             : 'rounded-t-[20px]',
+          isDetailFullscreen
+            ? `
+              *:data-[slot=drawer-handle]:absolute
+              *:data-[slot=drawer-handle]:top-4
+              *:data-[slot=drawer-handle]:left-1/2
+              *:data-[slot=drawer-handle]:z-10
+              *:data-[slot=drawer-handle]:-translate-x-1/2
+            `
+            : '',
         )}
       >
         <DrawerTitle className="sr-only">버스킹 장소 목록</DrawerTitle>
 
-        {isExpanded
+        {isExpanded && !isDetailFullscreen
           ? (
               <div
                 aria-hidden={true}
@@ -389,10 +412,18 @@ export function BuskingMapBottomSheet({
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           {isDetailOpen && !isCollapsed
             ? (
-                <div className="min-h-0 flex-1 px-2 pb-2">
+                <div
+                  className={cn(
+                    'min-h-0 flex-1',
+                    isDetailFullscreen
+                      ? 'px-0 pb-0'
+                      : 'px-2 pb-2',
+                  )}
+                >
                   <DetailPanel
                     place={selectedPlace ?? focusedPlace}
                     onCloseClick={handleDetailCloseClick}
+                    variant={isDetailFullscreen ? 'detail' : 'focused'}
                   />
                 </div>
               )

--- a/src/app/busking-map/_components/detail-panel.tsx
+++ b/src/app/busking-map/_components/detail-panel.tsx
@@ -1,5 +1,6 @@
 import type { UIEvent } from 'react';
 import type { BuskingPlace } from '@/types/busking-map';
+import { cva } from 'class-variance-authority';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useCallback, useMemo, useState } from 'react';
@@ -28,6 +29,35 @@ interface DetailPanelProps {
   onCloseClick: () => void;
   variant?: DetailPanelVariant;
 }
+
+const detailPanelVariants = cva(`
+  relative h-full w-full overflow-hidden bg-white
+`, {
+  variants: {
+    variant: {
+      focused: 'rounded-4xl shadow-sidebar',
+      detail: 'rounded-none shadow-none',
+    },
+  },
+  defaultVariants: {
+    variant: 'focused',
+  },
+});
+
+const detailPanelBodyVariants = cva(
+  'absolute inset-x-0 bottom-0 z-10 bg-white transition-all duration-200',
+  {
+    variants: {
+      variant: {
+        focused: 'rounded-t-4xl',
+        detail: 'rounded-none',
+      },
+    },
+    defaultVariants: {
+      variant: 'focused',
+    },
+  },
+);
 
 interface PerformanceItem {
   id: string;
@@ -307,15 +337,24 @@ function ApplicationGuidePanel({
   guides,
   onBackClick,
   onCloseClick,
+  variant = 'focused',
 }: {
   title: string;
   operatorUrl: string | null;
   guides: ApplicationGuideItem[];
   onBackClick: () => void;
   onCloseClick: () => void;
+  variant?: DetailPanelVariant;
 }) {
   return (
-    <div className="absolute inset-0 z-40 rounded-4xl bg-white">
+    <div
+      className={cn(
+        'absolute inset-0 z-40 bg-white',
+        variant === 'detail'
+          ? 'rounded-none'
+          : 'rounded-4xl',
+      )}
+    >
       <div className="absolute inset-x-0 top-0 z-20">
         <div className={`
           flex h-17 items-center justify-between border-b border-gray-200
@@ -424,7 +463,7 @@ function ApplicationGuidePanel({
   );
 }
 
-export function DetailPanel({ place, onCloseClick }: DetailPanelProps) {
+export function DetailPanel({ place, onCloseClick, variant = 'focused' }: DetailPanelProps) {
   const [isHeaderSolid, setIsHeaderSolid] = useState(false);
   const [isApplicationGuideOpen, setIsApplicationGuideOpen] = useState(false);
 
@@ -461,10 +500,7 @@ export function DetailPanel({ place, onCloseClick }: DetailPanelProps) {
 
   return (
     <section
-      className={`
-        relative h-full w-full overflow-hidden rounded-4xl bg-white
-        shadow-sidebar
-      `}
+      className={detailPanelVariants({ variant })}
     >
       {isApplicationGuideOpen
         ? (
@@ -472,6 +508,7 @@ export function DetailPanel({ place, onCloseClick }: DetailPanelProps) {
               title={place.title}
               operatorUrl={operatorUrl}
               guides={(applicationGuides?.applicationGuideResponses ?? []) as ApplicationGuideItem[]}
+              variant={variant}
               onBackClick={() => {
                 setIsApplicationGuideOpen(false);
               }}
@@ -515,10 +552,7 @@ export function DetailPanel({ place, onCloseClick }: DetailPanelProps) {
 
       <div
         className={cn(
-          `
-            absolute inset-x-0 bottom-0 z-10 rounded-t-4xl bg-white
-            transition-all duration-200
-          `,
+          detailPanelBodyVariants({ variant }),
           isHeaderSolid ? 'top-0' : 'top-44',
         )}
       >

--- a/src/app/busking-map/_components/detail-panel.tsx
+++ b/src/app/busking-map/_components/detail-panel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { UIEvent } from 'react';
 import type { BuskingPlace } from '@/types/busking-map';
 import { cva } from 'class-variance-authority';

--- a/src/app/busking-map/_components/index.ts
+++ b/src/app/busking-map/_components/index.ts
@@ -1,3 +1,4 @@
+export { BuskingMapBottomSheet } from './busking-map-bottom-sheet';
 export { BuskingMapHeaderSection } from './busking-map-header-section';
 export { BuskingMapMapSection } from './busking-map-map-section';
 export { BuskingMapSidebarSection } from './busking-map-sidebar-section';

--- a/src/app/busking-map/_components/sidebar-shell.tsx
+++ b/src/app/busking-map/_components/sidebar-shell.tsx
@@ -2,7 +2,9 @@
 
 import type { BuskingPlace } from '@/types/busking-map';
 import { useSidebarShellModel } from '@/hooks/busking-map';
+import { useMediaQuery } from '@/hooks/use-media-query';
 
+import { BuskingMapBottomSheet } from './busking-map-bottom-sheet';
 import { DetailPanel } from './detail-panel';
 import { SidebarLayout } from './sidebar-layout';
 import { SidebarOverlay } from './sidebar-overlay';
@@ -14,6 +16,22 @@ interface SidebarShellProps {
 
 export function SidebarShell({ places }: SidebarShellProps) {
   const model = useSidebarShellModel(places);
+  const isMobile = useMediaQuery('(max-width: 767px)');
+
+  if (isMobile) {
+    return (
+      <BuskingMapBottomSheet
+        activeTab={model.sidebar.activeTab}
+        places={model.sidebar.places}
+        focusedPlace={model.sidebar.focusedPlace}
+        selectedPlace={model.detail.place}
+        onTabClick={model.actions.onTabClick}
+        onListItemClick={model.actions.onListItemClick}
+        onFocusedCloseClick={model.actions.onFocusedCloseClick}
+        onDetailCloseClick={model.actions.onDetailCloseClick}
+      />
+    );
+  }
 
   return (
     <SidebarOverlay>

--- a/src/components/common/drawer/drawer.tsx
+++ b/src/components/common/drawer/drawer.tsx
@@ -1,3 +1,4 @@
+import { cva } from 'class-variance-authority';
 import * as React from 'react';
 import { Drawer as DrawerPrimitive } from 'vaul';
 
@@ -50,13 +51,37 @@ function DrawerOverlay({
 interface DrawerContentProps extends React.ComponentProps<typeof DrawerPrimitive.Content> {
   showOverlay?: boolean;
   overlayClassName?: string;
+  direction?: 'top' | 'right' | 'bottom' | 'left';
 }
+
+const drawerContentVariants = cva(`
+  group/drawer-content fixed z-50 flex h-auto flex-col bg-background
+`, {
+  variants: {
+    direction: {
+      top: 'inset-x-0 top-0 mb-24 max-h-[80vh] rounded-b-lg border-b',
+      bottom: 'inset-x-0 bottom-0 mt-24 max-h-[80vh] rounded-t-lg border-t',
+      right: `
+        inset-y-0 right-0 w-3/4 border-l
+        sm:max-w-sm
+      `,
+      left: `
+        inset-y-0 left-0 w-3/4 border-r
+        sm:max-w-sm
+      `,
+    },
+  },
+  defaultVariants: {
+    direction: 'bottom',
+  },
+});
 
 function DrawerContent({
   className,
   children,
   showOverlay = true,
   overlayClassName,
+  direction = 'bottom',
   ...props
 }: DrawerContentProps) {
   return (
@@ -64,40 +89,8 @@ function DrawerContent({
       {showOverlay ? <DrawerOverlay className={overlayClassName} /> : null}
       <DrawerPrimitive.Content
         data-slot="drawer-content"
-        className={cn(
-          'group/drawer-content fixed z-50 flex h-auto flex-col bg-background',
-          `
-            data-[vaul-drawer-direction=top]:inset-x-0
-            data-[vaul-drawer-direction=top]:top-0
-            data-[vaul-drawer-direction=top]:mb-24
-            data-[vaul-drawer-direction=top]:max-h-[80vh]
-            data-[vaul-drawer-direction=top]:rounded-b-lg
-            data-[vaul-drawer-direction=top]:border-b
-          `,
-          `
-            data-[vaul-drawer-direction=bottom]:inset-x-0
-            data-[vaul-drawer-direction=bottom]:bottom-0
-            data-[vaul-drawer-direction=bottom]:mt-24
-            data-[vaul-drawer-direction=bottom]:max-h-[80vh]
-            data-[vaul-drawer-direction=bottom]:rounded-t-lg
-            data-[vaul-drawer-direction=bottom]:border-t
-          `,
-          `
-            data-[vaul-drawer-direction=right]:inset-y-0
-            data-[vaul-drawer-direction=right]:right-0
-            data-[vaul-drawer-direction=right]:w-3/4
-            data-[vaul-drawer-direction=right]:border-l
-            data-[vaul-drawer-direction=right]:sm:max-w-sm
-          `,
-          `
-            data-[vaul-drawer-direction=left]:inset-y-0
-            data-[vaul-drawer-direction=left]:left-0
-            data-[vaul-drawer-direction=left]:w-3/4
-            data-[vaul-drawer-direction=left]:border-r
-            data-[vaul-drawer-direction=left]:sm:max-w-sm
-          `,
-          className,
-        )}
+        data-vaul-drawer-direction={direction}
+        className={cn(drawerContentVariants({ direction }), className)}
         {...props}
       >
         <div
@@ -149,7 +142,7 @@ function DrawerTitle({
   return (
     <DrawerPrimitive.Title
       data-slot="drawer-title"
-      className={cn('font-semibold text-foreground', className)}
+      className={cn('typo-body-sb-2 text-foreground', className)}
       {...props}
     />
   );
@@ -162,7 +155,7 @@ function DrawerDescription({
   return (
     <DrawerPrimitive.Description
       data-slot="drawer-description"
-      className={cn('text-sm text-muted-foreground', className)}
+      className={cn('typo-caption-r-1 text-muted-foreground', className)}
       {...props}
     />
   );

--- a/src/components/common/drawer/drawer.tsx
+++ b/src/components/common/drawer/drawer.tsx
@@ -1,0 +1,182 @@
+import * as React from 'react';
+import { Drawer as DrawerPrimitive } from 'vaul';
+
+import { cn } from '@/utils/index';
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        `
+          fixed inset-0 z-50 bg-black/50
+          data-[state=closed]:animate-out data-[state=closed]:fade-out-0
+          data-[state=open]:animate-in data-[state=open]:fade-in-0
+        `,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+interface DrawerContentProps extends React.ComponentProps<typeof DrawerPrimitive.Content> {
+  showOverlay?: boolean;
+  overlayClassName?: string;
+}
+
+function DrawerContent({
+  className,
+  children,
+  showOverlay = true,
+  overlayClassName,
+  ...props
+}: DrawerContentProps) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      {showOverlay ? <DrawerOverlay className={overlayClassName} /> : null}
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          'group/drawer-content fixed z-50 flex h-auto flex-col bg-background',
+          `
+            data-[vaul-drawer-direction=top]:inset-x-0
+            data-[vaul-drawer-direction=top]:top-0
+            data-[vaul-drawer-direction=top]:mb-24
+            data-[vaul-drawer-direction=top]:max-h-[80vh]
+            data-[vaul-drawer-direction=top]:rounded-b-lg
+            data-[vaul-drawer-direction=top]:border-b
+          `,
+          `
+            data-[vaul-drawer-direction=bottom]:inset-x-0
+            data-[vaul-drawer-direction=bottom]:bottom-0
+            data-[vaul-drawer-direction=bottom]:mt-24
+            data-[vaul-drawer-direction=bottom]:max-h-[80vh]
+            data-[vaul-drawer-direction=bottom]:rounded-t-lg
+            data-[vaul-drawer-direction=bottom]:border-t
+          `,
+          `
+            data-[vaul-drawer-direction=right]:inset-y-0
+            data-[vaul-drawer-direction=right]:right-0
+            data-[vaul-drawer-direction=right]:w-3/4
+            data-[vaul-drawer-direction=right]:border-l
+            data-[vaul-drawer-direction=right]:sm:max-w-sm
+          `,
+          `
+            data-[vaul-drawer-direction=left]:inset-y-0
+            data-[vaul-drawer-direction=left]:left-0
+            data-[vaul-drawer-direction=left]:w-3/4
+            data-[vaul-drawer-direction=left]:border-r
+            data-[vaul-drawer-direction=left]:sm:max-w-sm
+          `,
+          className,
+        )}
+        {...props}
+      >
+        <div
+          data-slot="drawer-handle"
+          className={`
+            mx-auto mt-4 hidden h-2 w-[100px] shrink-0 cursor-pointer
+            rounded-full bg-muted
+            group-data-[vaul-drawer-direction=bottom]/drawer-content:block
+          `}
+        />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        `
+          flex flex-col gap-0.5 p-4
+          group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center
+          group-data-[vaul-drawer-direction=top]/drawer-content:text-center
+          md:gap-1.5 md:text-left
+        `,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn('font-semibold text-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+};

--- a/src/components/common/drawer/index.ts
+++ b/src/components/common/drawer/index.ts
@@ -1,0 +1,12 @@
+export {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+} from './drawer';


### PR DESCRIPTION
## 관련 이슈
<!-- 이슈 번호를 입력하세요. -->

Closes #277 

## 변경사항

<!-- 주요 변경사항을 작성하세요. -->
- shadcn Drawer 기반 바텀시트 추가
- `collapsed / default / expanded` 3단계 snap point 동작 적용
- 접힘 상태에서는 대표 공연 장소 1개만 노출
- 기본 상태에서는 장소 목록/검색 결과 목록만 노출하도록 조정
- 확장 상태에서는 검색 헤더 아래까지만 올라오도록 높이 보정
- 확장 상태에서 상단 radius와 shadow를 제거해 헤더와 하나의 화면처럼 보이도록 수정
- 확장 상태에서도 다시 아래로 드래그할 수 있도록 상단 drag 영역 유지

## 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->
- 모바일에서 접힘 상태는 대표 장소 1개만 보이는지
- 기본 상태에서는 프리뷰 카드 없이 탭과 목록만 보이는지
- 확장 상태에서는 검색 헤더 바로 아래까지 붙고 상단 radius/shadow가 제거되는지
- 확장 상태에서 다시 아래로 드래그해 기본/접힘 상태로 복귀 가능한지


## 추가 정보

<!-- 스크린샷, 테스트 방법 등 추가 정보가 있다면 작성하세요 -->

<img width="355" height="559" alt="image" src="https://github.com/user-attachments/assets/922a5dd2-1e92-4bbd-94ad-89296cd1ef48" />
