### PR TITLE
fix: sitemap 및 noindex SEO 정책 정리

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,6 +1,13 @@
+import type { Metadata } from 'next';
 import { cn } from '@/utils';
+import { NO_INDEX_FOLLOW_ROBOTS } from '@/utils/seo';
 
 import { LoginHeader, LoginKakaoSection } from './_components';
+
+export const metadata: Metadata = {
+  title: '로그인',
+  robots: NO_INDEX_FOLLOW_ROBOTS,
+};
 
 export default function LoginPage() {
   return (

--- a/src/app/(auth)/oauth-callback/[provider]/_components/oauth-callback-client.tsx
+++ b/src/app/(auth)/oauth-callback/[provider]/_components/oauth-callback-client.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+import { exchangeToken } from '@/apis/token';
+
+export function OAuthCallbackClient() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+
+    if (code) {
+      exchangeToken({ code }).then(() => {
+        router.push('/');
+      }).catch(() => {
+        router.push('/login');
+      });
+    }
+  }, [router, searchParams]);
+
+  // !todo: 로그인 중... jsx를 shadcn/ui Spinner 컴포넌트로 변경 예정
+  // !todo: 현재 브랜치에서 변경하기 어려운 이유: 로그인 관련 작업 브랜치에서 shadcn/ui에서 제공하는 컴포넌트 설치 작업은 브랜치 규칙 위반.
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="animate-pulse">로그인 중...</div>
+    </div>
+  );
+}

--- a/src/app/(auth)/oauth-callback/[provider]/page.tsx
+++ b/src/app/(auth)/oauth-callback/[provider]/page.tsx
@@ -1,27 +1,22 @@
-'use client';
+import type { Metadata } from 'next';
+import { Suspense } from 'react';
+import { NO_INDEX_FOLLOW_ROBOTS } from '@/utils/seo';
+import { OAuthCallbackClient } from './_components/oauth-callback-client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
-import { exchangeToken } from '@/apis/token';
+export const metadata: Metadata = {
+  title: '로그인 처리',
+  robots: NO_INDEX_FOLLOW_ROBOTS,
+};
 
 export default function OAuthCallbackPage() {
-  const searchParams = useSearchParams();
-  const router = useRouter();
+  return (
+    <Suspense fallback={<OAuthCallbackPending />}>
+      <OAuthCallbackClient />
+    </Suspense>
+  );
+}
 
-  useEffect(() => {
-    const code = searchParams.get('code');
-
-    if (code) {
-      exchangeToken({ code }).then(() => {
-        router.push('/');
-      }).catch(() => {
-        router.push('/login');
-      });
-    }
-  }, [router, searchParams]);
-
-  // !todo: 로그인 중... jsx를 shadcn/ui Spinner 컴포넌트로 변경 예정
-  // !todo: 현재 브랜치에서 변경하기 어려운 이유: 로그인 관련 작업 브랜치에서 shadcn/ui에서 제공하는 컴포넌트 설치 작업은 브랜치 규칙 위반.
+function OAuthCallbackPending() {
   return (
     <div className="flex min-h-screen items-center justify-center">
       <div className="animate-pulse">로그인 중...</div>

--- a/src/app/(main)/performance-detail/[performanceId]/page.tsx
+++ b/src/app/(main)/performance-detail/[performanceId]/page.tsx
@@ -6,13 +6,19 @@ import { JsonLdScript } from '@/components/seo';
 import { getQueryClient } from '@/queries';
 import { performanceDetailQueryOptions } from '@/queries/performance';
 import { createPageMetadata } from '@/utils';
-import { buildPerformanceBreadcrumbJsonLd, buildPerformanceEventJsonLd } from '@/utils/seo';
+import {
+  buildPerformanceBreadcrumbJsonLd,
+  buildPerformanceEventJsonLd,
+  NO_INDEX_FOLLOW_ROBOTS,
+} from '@/utils/seo';
 import { Footer, PerformanceInfo } from './_components';
 
 const getPerformanceDetail = cache(async (performanceId: number) => {
   const queryClient = getQueryClient();
 
-  return queryClient.fetchQuery(performanceDetailQueryOptions(performanceId));
+  return queryClient.fetchQuery(
+    performanceDetailQueryOptions(performanceId),
+  );
 });
 
 export async function generateMetadata(
@@ -30,6 +36,7 @@ export async function generateMetadata(
       title: '공연 상세',
       description: '버스킹 공연 상세 정보와 일정, 장소, 진행 내용을 확인해보세요.',
       path: '/performance-detail',
+      robots: NO_INDEX_FOLLOW_ROBOTS,
     });
   }
 
@@ -40,6 +47,7 @@ export async function generateMetadata(
     description: `${performanceDetail.title} 공연의 일정, 장소, 상세 정보를 확인해보세요.`,
     path: `/performance-detail/${performanceId}`,
     image: performanceDetail.imageUrl ?? undefined,
+    robots: NO_INDEX_FOLLOW_ROBOTS,
   });
 }
 
@@ -70,8 +78,15 @@ export default async function PerformanceDetailPage(
 
   return (
     <div className="relative container-1920 flex min-h-screen flex-col">
-      <JsonLdScript id="performance-event-json-ld" data={eventJsonLd} />
-      <JsonLdScript id="performance-breadcrumb-json-ld" data={breadcrumbJsonLd} />
+      <JsonLdScript
+        id="performance-event-json-ld"
+        data={eventJsonLd}
+      />
+      <JsonLdScript
+        id="performance-breadcrumb-json-ld"
+        data={breadcrumbJsonLd}
+      />
+
       <main className="flex flex-1 flex-col">
         <HydrationBoundary state={dehydrate(queryClient)}>
           <Suspense fallback={<div>Loading...</div>}>
@@ -79,6 +94,7 @@ export default async function PerformanceDetailPage(
           </Suspense>
         </HydrationBoundary>
       </main>
+
       <Footer />
     </div>
   );

--- a/src/app/(main)/performance-list/page.tsx
+++ b/src/app/(main)/performance-list/page.tsx
@@ -36,7 +36,7 @@ export default async function PerformanceListPage({ searchParams }: PageProps) {
   return (
     <div className="relative container-1920 flex min-h-screen flex-col">
       <main className="min-h-screen bg-white pt-[57px]">
-
+        <h1 className="sr-only">버스킹 공연 정보</h1>
         <Hero />
         <HydrationBoundary state={dehydrate(queryClient)}>
           <Suspense

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -4,12 +4,14 @@ import { getUser } from '@/apis/user';
 import { getQueryClient } from '@/queries';
 import { userQueryOptions } from '@/queries/user/user.query';
 import { createPageMetadata } from '@/utils';
+import { NO_INDEX_FOLLOW_ROBOTS } from '@/utils/seo';
 import { Footer, ProfileTab } from './_components';
 
 export const metadata = createPageMetadata({
   title: '마이페이지',
   description: '내가 등록한 공연과 계정 정보를 한곳에서 확인해보세요.',
   path: '/profile',
+  robots: NO_INDEX_FOLLOW_ROBOTS,
 });
 
 export default async function ProfilePage() {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,14 +1,7 @@
 import type { MetadataRoute } from 'next';
-import type { PerformanceFilterTab } from '@/types/performance';
-import { getPerformanceList } from '@/apis/performance';
-import { routePaths } from '@/utils';
 import { toAbsoluteUrl } from '@/utils/seo';
 
 export const revalidate = 3600;
-
-// API가 잘못된 페이지네이션 응답을 반환해도 사이트맵 생성이 무한 루프에 빠지지 않도록 최대 페이지 수를 제한
-// 추후 최대 공연 수에 따라 변동
-const MAX_PERFORMANCE_PAGES = 200;
 
 const STATIC_PAGES: Array<{
   path: string;
@@ -17,89 +10,13 @@ const STATIC_PAGES: Array<{
 }> = [
   { path: '/', changeFrequency: 'daily', priority: 1 },
   { path: '/about-us', changeFrequency: 'monthly', priority: 0.7 },
-  { path: '/performance-list', changeFrequency: 'daily', priority: 0.9 },
   { path: '/busking-map', changeFrequency: 'daily', priority: 0.8 },
+  { path: '/performance-list', changeFrequency: 'daily', priority: 0.9 },
 ];
 
-async function getPerformanceIds(type: PerformanceFilterTab): Promise<number[]> {
-  const performanceIds: number[] = [];
-  let page = 0;
-
-  while (page < MAX_PERFORMANCE_PAGES) {
-    const { content, hasNext } = await getPerformanceList(type, page, {
-      skipRedirectOn401: true,
-    });
-
-    performanceIds.push(...content.map(({ performanceId }) => performanceId));
-
-    if (!hasNext) {
-      return performanceIds;
-    }
-
-    if (content.length === 0) {
-      console.warn(`사이트맵: ${type} ${page} 페이지 응답이 비어 있어 순회를 중단`);
-      return performanceIds;
-    }
-
-    page += 1;
-  }
-
-  // 변경: 최대 페이지 상한에 도달한 경우에도 현재까지 수집한 ID로 사이트맵 생성
-  console.warn(`사이트맵: ${type} 페이지 상한(${MAX_PERFORMANCE_PAGES})에 도달함`);
-  return performanceIds;
-}
-
-function getUniqueValues<TValue>(values: TValue[]): TValue[] {
-  return Array.from(new Set(values));
-}
-
-async function getPerformanceIdsSafely(): Promise<number[]> {
-  const performanceIdResults = await Promise.allSettled([
-    getPerformanceIds('upcoming'),
-    getPerformanceIds('past'),
-  ]);
-
-  const performanceIds = performanceIdResults.flatMap((result) => {
-    if (result.status === 'rejected') {
-      console.error('사이트맵 생성 중 공연 ID 조회에 실패했습니다.', result.reason);
-      return [];
-    }
-
-    return result.value;
-  });
-
-  return getUniqueValues(performanceIds);
-}
-
-async function getPerformanceDetailEntries(): Promise<MetadataRoute.Sitemap> {
-  try {
-    const performanceIds = await getPerformanceIdsSafely();
-
-    return performanceIds.map(performanceId => ({
-      url: toAbsoluteUrl(routePaths.performanceDetail(performanceId)),
-      changeFrequency: 'weekly',
-      priority: 0.6,
-    }));
-  }
-  catch (error) {
-    console.error('사이트맵 생성 중 공연 상세 URL 목록 생성에 실패했습니다.', error);
-    return [];
-  }
-}
-
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const lastModified = new Date();
-  const performanceDetailEntries = await getPerformanceDetailEntries();
-
-  return [
-    ...STATIC_PAGES.map(({ path, ...metadata }) => ({
-      url: toAbsoluteUrl(path),
-      lastModified,
-      ...metadata,
-    })),
-    ...performanceDetailEntries.map(entry => ({
-      ...entry,
-      lastModified,
-    })),
-  ];
+export default function sitemap(): MetadataRoute.Sitemap {
+  return STATIC_PAGES.map(({ path, ...metadata }) => ({
+    url: toAbsoluteUrl(path),
+    ...metadata,
+  }));
 }

--- a/src/utils/create-page-metadata.ts
+++ b/src/utils/create-page-metadata.ts
@@ -5,6 +5,7 @@ interface CreatePageMetadataParams {
   description?: string;
   path?: string;
   image?: string;
+  robots?: Metadata['robots'];
 }
 
 const DEFAULT_DESCRIPTION
@@ -27,6 +28,7 @@ export function createPageMetadata({
   description = DEFAULT_DESCRIPTION,
   path = '/',
   image = DEFAULT_IMAGE,
+  robots,
 }: CreatePageMetadataParams): Metadata {
   return {
     title,
@@ -47,5 +49,6 @@ export function createPageMetadata({
       description,
       images: [image],
     },
+    robots,
   };
 }

--- a/src/utils/seo/index.ts
+++ b/src/utils/seo/index.ts
@@ -1,3 +1,4 @@
 export { getHomeOrganizationJsonLd, getHomeWebsiteJsonLd, HOME_DESCRIPTION } from './home-json-ld';
 export { buildPerformanceBreadcrumbJsonLd, buildPerformanceEventJsonLd } from './performance-json-ld';
+export { NO_INDEX_FOLLOW_ROBOTS } from './robots';
 export { toAbsoluteUrl } from './site-url';

--- a/src/utils/seo/robots.ts
+++ b/src/utils/seo/robots.ts
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const NO_INDEX_FOLLOW_ROBOTS: Metadata['robots'] = {
+  index: false,
+  follow: true,
+  googleBot: {
+    index: false,
+    follow: true,
+  },
+};


### PR DESCRIPTION
## 관련 이슈

<!-- 이슈 번호를 입력하세요. -->

Closes #280  

## 변경사항

<!-- 주요 변경사항을 작성하세요. -->
-  sitemap이 홈, About Us, 버스킹 맵, 공연 정보 4개 대표 공개 페이지만 포함하도록 정리
- 공연 상세 페이지가 sitemap에 포함되지 않도록 동적 생성 로직을 제거
- 로그인, OAuth 콜백, 마이페이지, 공연 상세 페이지에 공통 `noindex, follow` 정책을 적용
- 반복되던 robots 메타데이터를 공통 SEO 상수로 추출
- 공연 정보 페이지의 문서 구조를 보완하기 위해 `sr-only h1`을 추가
- OAuth 콜백 페이지를 서버 메타데이터 페이지와 클라이언트 리다이렉트 컴포넌트로 분리


## 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->
- 대표 공개 페이지 4개만 sitemap에 포함되는지 확인
- 로그인, OAuth 콜백, 마이페이지, 공연 상세 페이지에 `noindex` 메타데이터가 정상 적용되는지 확인
- OAuth 콜백 페이지 분리 이후 기존 로그인 리다이렉트 동작에 영향이 없는지 확인
