### PR TITLE
hotfix: next.config.ts 내 quality 허용값 설정(이미지 깨짐 현상 수정)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,9 @@ const nextConfig: NextConfig = {
     // 최신 형식 우선 (AVIF > WebP > JPEG)
     formats: ['image/avif', 'image/webp'],
 
+    // 배경 이미지 q=45와 기본 q=75 허용
+    qualities: [45, 75],
+
     // 캐싱 1년 (Cloudflare 활용)
     minimumCacheTTL: 31536000,
 

--- a/src/app/(main)/_components/home-hero-section.tsx
+++ b/src/app/(main)/_components/home-hero-section.tsx
@@ -131,7 +131,6 @@ export function HomeHeroSection({ mapBgSrc, heroIllustSrc }: HomeHeroSectionProp
                     priority
                     fetchPriority="high"
                     sizes="(max-width: 1023px) 100vw, 1280px"
-                    quality={70}
                     className="object-contain"
                   />
                 </div>


### PR DESCRIPTION
## 관련 이슈

<!-- 이슈 번호를 입력하세요. -->

Closes #285 

## 변경사항

<!-- 주요 변경사항을 작성하세요. -->
- Home 페이지 내 main-image quality값 75로 조정
- next.config.ts 내 quality 허용값 [45, 75] 설정
    -  75는 default 값이나, 명시적으로 작성해두었음

## 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->
- 오류 없이 이미지가 배포 사이트에 노출되는지 확인

## 추가 정보

<!-- 스크린샷, 테스트 방법 등 추가 정보가 있다면 작성하세요 -->